### PR TITLE
fix: 동일한 사용자가 동일한 식별자를 가진 시간표를 두 번 이상 제출할 때 의도하지 않은 오류가 발생했던 문제 해결

### DIFF
--- a/src/main/java/aegis/server/domain/timetable/repository/TimetableRepository.java
+++ b/src/main/java/aegis/server/domain/timetable/repository/TimetableRepository.java
@@ -5,13 +5,10 @@ import aegis.server.domain.member.domain.Member;
 import aegis.server.domain.timetable.domain.Timetable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface TimetableRepository extends JpaRepository<Timetable, Long> {
-    List<Timetable> findByYearSemester(YearSemester yearSemester);
-
-    boolean existsByIdentifierAndYearSemester(String identifier, YearSemester yearSemester);
-
     Optional<Timetable> findByMemberAndYearSemester(Member member, YearSemester yearSemester);
+
+    Optional<Timetable> findByIdentifierAndYearSemester(String identifier, YearSemester yearSemester);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 시간표 업데이트 처리가 개선되어, 동일 계정 내에서는 기존 시간표를 원활하게 업데이트할 수 있으며, 타 계정과의 식별자 충돌이 효과적으로 방지됩니다.
- **테스트**
  - 시간표 업데이트 시나리오에 대한 테스트 케이스가 보강되어, 다양한 업데이트 상황에서 안정성을 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->