### PR TITLE
fix(BE-51): swagger의 오류 응답에 정상 응답 스키마가 나타나는 문제 해결

### DIFF
--- a/src/main/java/aegis/server/domain/coupon/controller/AdminCouponController.java
+++ b/src/main/java/aegis/server/domain/coupon/controller/AdminCouponController.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import org.springframework.http.HttpStatus;
@@ -33,17 +32,20 @@ public class AdminCouponController {
 
     private final CouponService couponService;
 
-    @Operation(summary = "모든 쿠폰 조회", description = "관리자가 등록된 모든 쿠폰을 조회합니다.")
-    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "쿠폰 조회 성공")})
+    @Operation(
+            summary = "모든 쿠폰 조회",
+            description = "관리자가 등록된 모든 쿠폰을 조회합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "쿠폰 조회 성공")})
     @GetMapping
     public ResponseEntity<List<CouponResponse>> getAllCoupons() {
         List<CouponResponse> response = couponService.findAllCoupons();
         return ResponseEntity.ok().body(response);
     }
 
-    @Operation(summary = "쿠폰 생성", description = "새로운 쿠폰을 생성합니다.")
-    @ApiResponses(
-            value = {
+    @Operation(
+            summary = "쿠폰 생성",
+            description = "새로운 쿠폰을 생성합니다.",
+            responses = {
                 @ApiResponse(responseCode = "201", description = "쿠폰 생성 성공"),
                 @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content),
                 @ApiResponse(responseCode = "409", description = "동일한 이름과 할인금액의 쿠폰이 이미 존재", content = @Content)
@@ -54,9 +56,10 @@ public class AdminCouponController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @Operation(summary = "쿠폰 삭제", description = "지정된 ID의 쿠폰을 삭제합니다.")
-    @ApiResponses(
-            value = {
+    @Operation(
+            summary = "쿠폰 삭제",
+            description = "지정된 ID의 쿠폰을 삭제합니다.",
+            responses = {
                 @ApiResponse(responseCode = "204", description = "쿠폰 삭제 성공"),
                 @ApiResponse(responseCode = "404", description = "존재하지 않는 쿠폰", content = @Content),
                 @ApiResponse(responseCode = "409", description = "발급된 쿠폰이 있어 삭제할 수 없음", content = @Content)
@@ -69,17 +72,20 @@ public class AdminCouponController {
 
     // - - -
 
-    @Operation(summary = "모든 발급된 쿠폰 조회", description = "관리자가 발급된 모든 쿠폰을 조회합니다.")
-    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "발급된 쿠폰 조회 성공")})
+    @Operation(
+            summary = "모든 발급된 쿠폰 조회",
+            description = "관리자가 발급된 모든 쿠폰을 조회합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "발급된 쿠폰 조회 성공")})
     @GetMapping("/issued")
     public ResponseEntity<List<IssuedCouponResponse>> getAllIssuedCoupons() {
         List<IssuedCouponResponse> response = couponService.findAllIssuedCoupons();
         return ResponseEntity.ok().body(response);
     }
 
-    @Operation(summary = "쿠폰 발급", description = "특정 사용자들에게 쿠폰을 발급합니다.")
-    @ApiResponses(
-            value = {
+    @Operation(
+            summary = "쿠폰 발급",
+            description = "특정 사용자들에게 쿠폰을 발급합니다.",
+            responses = {
                 @ApiResponse(responseCode = "201", description = "쿠폰 발급 성공"),
                 @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content),
                 @ApiResponse(responseCode = "404", description = "존재하지 않는 쿠폰 또는 사용자", content = @Content)
@@ -90,9 +96,10 @@ public class AdminCouponController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @Operation(summary = "발급된 쿠폰 삭제", description = "지정된 ID의 발급된 쿠폰을 삭제합니다.")
-    @ApiResponses(
-            value = {
+    @Operation(
+            summary = "발급된 쿠폰 삭제",
+            description = "지정된 ID의 발급된 쿠폰을 삭제합니다.",
+            responses = {
                 @ApiResponse(responseCode = "204", description = "발급된 쿠폰 삭제 성공"),
                 @ApiResponse(responseCode = "404", description = "존재하지 않는 발급된 쿠폰", content = @Content)
             })
@@ -104,17 +111,20 @@ public class AdminCouponController {
 
     // - - -
 
-    @Operation(summary = "모든 쿠폰 코드 조회", description = "관리자가 생성된 모든 쿠폰 코드를 조회합니다.")
-    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "쿠폰 코드 조회 성공")})
+    @Operation(
+            summary = "모든 쿠폰 코드 조회",
+            description = "관리자가 생성된 모든 쿠폰 코드를 조회합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "쿠폰 코드 조회 성공")})
     @GetMapping("/code")
     public ResponseEntity<List<CouponCodeResponse>> getAllCodeCoupons() {
         List<CouponCodeResponse> response = couponService.findAllCouponCode();
         return ResponseEntity.ok().body(response);
     }
 
-    @Operation(summary = "쿠폰 코드 생성", description = "지정된 쿠폰에 대한 코드를 생성합니다.")
-    @ApiResponses(
-            value = {
+    @Operation(
+            summary = "쿠폰 코드 생성",
+            description = "지정된 쿠폰에 대한 코드를 생성합니다.",
+            responses = {
                 @ApiResponse(responseCode = "201", description = "쿠폰 코드 생성 성공"),
                 @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content),
                 @ApiResponse(responseCode = "404", description = "존재하지 않는 쿠폰", content = @Content),
@@ -126,9 +136,10 @@ public class AdminCouponController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @Operation(summary = "쿠폰 코드 삭제", description = "지정된 ID의 쿠폰 코드를 삭제합니다.")
-    @ApiResponses(
-            value = {
+    @Operation(
+            summary = "쿠폰 코드 삭제",
+            description = "지정된 ID의 쿠폰 코드를 삭제합니다.",
+            responses = {
                 @ApiResponse(responseCode = "204", description = "쿠폰 코드 삭제 성공"),
                 @ApiResponse(responseCode = "404", description = "존재하지 않는 쿠폰 코드", content = @Content)
             })

--- a/src/main/java/aegis/server/domain/coupon/controller/AdminCouponController.java
+++ b/src/main/java/aegis/server/domain/coupon/controller/AdminCouponController.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -44,8 +45,8 @@ public class AdminCouponController {
     @ApiResponses(
             value = {
                 @ApiResponse(responseCode = "201", description = "쿠폰 생성 성공"),
-                @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
-                @ApiResponse(responseCode = "409", description = "동일한 이름과 할인금액의 쿠폰이 이미 존재")
+                @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content),
+                @ApiResponse(responseCode = "409", description = "동일한 이름과 할인금액의 쿠폰이 이미 존재", content = @Content)
             })
     @PostMapping
     public ResponseEntity<Void> createCoupon(@Valid @RequestBody CouponCreateRequest request) {
@@ -57,8 +58,8 @@ public class AdminCouponController {
     @ApiResponses(
             value = {
                 @ApiResponse(responseCode = "204", description = "쿠폰 삭제 성공"),
-                @ApiResponse(responseCode = "404", description = "존재하지 않는 쿠폰"),
-                @ApiResponse(responseCode = "409", description = "발급된 쿠폰이 있어 삭제할 수 없음")
+                @ApiResponse(responseCode = "404", description = "존재하지 않는 쿠폰", content = @Content),
+                @ApiResponse(responseCode = "409", description = "발급된 쿠폰이 있어 삭제할 수 없음", content = @Content)
             })
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteCoupon(@Parameter(description = "삭제할 쿠폰 ID") @PathVariable Long id) {
@@ -80,8 +81,8 @@ public class AdminCouponController {
     @ApiResponses(
             value = {
                 @ApiResponse(responseCode = "201", description = "쿠폰 발급 성공"),
-                @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
-                @ApiResponse(responseCode = "404", description = "존재하지 않는 쿠폰 또는 사용자")
+                @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content),
+                @ApiResponse(responseCode = "404", description = "존재하지 않는 쿠폰 또는 사용자", content = @Content)
             })
     @PostMapping("/issued")
     public ResponseEntity<Void> createIssuedCoupon(@Valid @RequestBody CouponIssueRequest request) {
@@ -93,7 +94,7 @@ public class AdminCouponController {
     @ApiResponses(
             value = {
                 @ApiResponse(responseCode = "204", description = "발급된 쿠폰 삭제 성공"),
-                @ApiResponse(responseCode = "404", description = "존재하지 않는 발급된 쿠폰")
+                @ApiResponse(responseCode = "404", description = "존재하지 않는 발급된 쿠폰", content = @Content)
             })
     @DeleteMapping("/issued/{id}")
     public ResponseEntity<Void> deleteIssuedCoupon(@Parameter(description = "삭제할 발급된 쿠폰 ID") @PathVariable Long id) {
@@ -115,9 +116,9 @@ public class AdminCouponController {
     @ApiResponses(
             value = {
                 @ApiResponse(responseCode = "201", description = "쿠폰 코드 생성 성공"),
-                @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
-                @ApiResponse(responseCode = "404", description = "존재하지 않는 쿠폰"),
-                @ApiResponse(responseCode = "500", description = "고유 쿠폰 코드 생성 실패 (100회 시도 후 실패)")
+                @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content),
+                @ApiResponse(responseCode = "404", description = "존재하지 않는 쿠폰", content = @Content),
+                @ApiResponse(responseCode = "500", description = "고유 쿠폰 코드 생성 실패 (100회 시도 후 실패)", content = @Content)
             })
     @PostMapping("/code")
     public ResponseEntity<Void> createCodeCoupon(@Valid @RequestBody CouponCodeCreateRequest request) {
@@ -129,7 +130,7 @@ public class AdminCouponController {
     @ApiResponses(
             value = {
                 @ApiResponse(responseCode = "204", description = "쿠폰 코드 삭제 성공"),
-                @ApiResponse(responseCode = "404", description = "존재하지 않는 쿠폰 코드")
+                @ApiResponse(responseCode = "404", description = "존재하지 않는 쿠폰 코드", content = @Content)
             })
     @DeleteMapping("/code/{id}")
     public ResponseEntity<Void> deleteCodeCoupon(@Parameter(description = "삭제할 쿠폰 코드 ID") @PathVariable Long id) {

--- a/src/main/java/aegis/server/domain/coupon/controller/CouponController.java
+++ b/src/main/java/aegis/server/domain/coupon/controller/CouponController.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import org.springframework.http.ResponseEntity;
@@ -30,9 +29,10 @@ public class CouponController {
 
     private final CouponService couponService;
 
-    @Operation(summary = "내 발급된 쿠폰 조회", description = "로그인한 사용자의 유효한 발급된 쿠폰을 모두 조회합니다.")
-    @ApiResponses(
-            value = {
+    @Operation(
+            summary = "내 발급된 쿠폰 조회",
+            description = "로그인한 사용자의 유효한 발급된 쿠폰을 모두 조회합니다.",
+            responses = {
                 @ApiResponse(responseCode = "200", description = "쿠폰 조회 성공"),
                 @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content)
             })
@@ -43,9 +43,10 @@ public class CouponController {
         return ResponseEntity.ok().body(responses);
     }
 
-    @Operation(summary = "쿠폰 코드 사용", description = "쿠폰 코드를 사용하여 쿠폰을 발급받습니다.")
-    @ApiResponses(
-            value = {
+    @Operation(
+            summary = "쿠폰 코드 사용",
+            description = "쿠폰 코드를 사용하여 쿠폰을 발급받습니다.",
+            responses = {
                 @ApiResponse(responseCode = "200", description = "쿠폰 코드 사용 성공"),
                 @ApiResponse(responseCode = "400", description = "잘못된 쿠폰 코드 형식", content = @Content),
                 @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),

--- a/src/main/java/aegis/server/domain/coupon/controller/CouponController.java
+++ b/src/main/java/aegis/server/domain/coupon/controller/CouponController.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -33,7 +34,7 @@ public class CouponController {
     @ApiResponses(
             value = {
                 @ApiResponse(responseCode = "200", description = "쿠폰 조회 성공"),
-                @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+                @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content)
             })
     @GetMapping("/issued/me")
     public ResponseEntity<List<IssuedCouponResponse>> getMyAllValidIssuedCoupon(
@@ -46,10 +47,10 @@ public class CouponController {
     @ApiResponses(
             value = {
                 @ApiResponse(responseCode = "200", description = "쿠폰 코드 사용 성공"),
-                @ApiResponse(responseCode = "400", description = "잘못된 쿠폰 코드 형식"),
-                @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
-                @ApiResponse(responseCode = "404", description = "존재하지 않는 쿠폰 코드"),
-                @ApiResponse(responseCode = "409", description = "이미 사용된 쿠폰 코드 또는 중복 사용")
+                @ApiResponse(responseCode = "400", description = "잘못된 쿠폰 코드 형식", content = @Content),
+                @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+                @ApiResponse(responseCode = "404", description = "존재하지 않는 쿠폰 코드", content = @Content),
+                @ApiResponse(responseCode = "409", description = "이미 사용된 쿠폰 코드 또는 중복 사용", content = @Content)
             })
     @PostMapping("/code")
     public ResponseEntity<Void> codeCouponIssue(

--- a/src/main/java/aegis/server/domain/discord/controller/DiscordController.java
+++ b/src/main/java/aegis/server/domain/discord/controller/DiscordController.java
@@ -2,6 +2,7 @@ package aegis.server.domain.discord.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -35,8 +36,8 @@ public class DiscordController {
     @ApiResponses(
             value = {
                 @ApiResponse(responseCode = "200", description = "디스코드 ID 조회 성공"),
-                @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
-                @ApiResponse(responseCode = "404", description = "디스코드 연동 정보찾을 수 없음")
+                @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+                @ApiResponse(responseCode = "404", description = "디스코드 연동 정보찾을 수 없음", content = @Content)
             })
     @GetMapping("/myid")
     public ResponseEntity<DiscordIdResponse> getDiscordId(
@@ -48,9 +49,9 @@ public class DiscordController {
     @ApiResponses(
             value = {
                 @ApiResponse(responseCode = "201", description = "인증 코드 발급 성공"),
-                @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
-                @ApiResponse(responseCode = "404", description = "사용자 정보를 찾을 수 없음"),
-                @ApiResponse(responseCode = "500", description = "인증 코드 생성 실패 (100회 시도 후 실패)")
+                @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+                @ApiResponse(responseCode = "404", description = "사용자 정보를 찾을 수 없음", content = @Content),
+                @ApiResponse(responseCode = "500", description = "인증 코드 생성 실패 (100회 시도 후 실패)", content = @Content)
             })
     @PostMapping("/issue-verification-code")
     public ResponseEntity<DiscordVerificationCodeResponse> getVerificationCode(

--- a/src/main/java/aegis/server/domain/discord/controller/DiscordController.java
+++ b/src/main/java/aegis/server/domain/discord/controller/DiscordController.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import org.springframework.http.HttpStatus;
@@ -32,9 +31,10 @@ public class DiscordController {
 
     private final DiscordService discordService;
 
-    @Operation(summary = "내 디스코드 ID 조회", description = "로그인한 사용자의 연동된 디스코드 ID를 조회합니다.")
-    @ApiResponses(
-            value = {
+    @Operation(
+            summary = "내 디스코드 ID 조회",
+            description = "로그인한 사용자의 연동된 디스코드 ID를 조회합니다.",
+            responses = {
                 @ApiResponse(responseCode = "200", description = "디스코드 ID 조회 성공"),
                 @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
                 @ApiResponse(responseCode = "404", description = "디스코드 연동 정보찾을 수 없음", content = @Content)
@@ -45,9 +45,10 @@ public class DiscordController {
         return ResponseEntity.ok(discordService.getDiscordId(userDetails));
     }
 
-    @Operation(summary = "디스코드 인증 코드 발급", description = "디스코드 연동을 위한 인증 코드를 발급합니다.")
-    @ApiResponses(
-            value = {
+    @Operation(
+            summary = "디스코드 인증 코드 발급",
+            description = "디스코드 연동을 위한 인증 코드를 발급합니다.",
+            responses = {
                 @ApiResponse(responseCode = "201", description = "인증 코드 발급 성공"),
                 @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
                 @ApiResponse(responseCode = "404", description = "사용자 정보를 찾을 수 없음", content = @Content),

--- a/src/main/java/aegis/server/domain/member/controller/MemberController.java
+++ b/src/main/java/aegis/server/domain/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -32,8 +33,8 @@ public class MemberController {
     @ApiResponses(
             value = {
                 @ApiResponse(responseCode = "200", description = "개인정보 조회 성공"),
-                @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
-                @ApiResponse(responseCode = "404", description = "사용자 정보를 찾을 수 없음")
+                @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+                @ApiResponse(responseCode = "404", description = "사용자 정보를 찾을 수 없음", content = @Content)
             })
     @GetMapping
     public ResponseEntity<PersonalInfoResponse> getPersonalInfo(
@@ -45,9 +46,9 @@ public class MemberController {
     @ApiResponses(
             value = {
                 @ApiResponse(responseCode = "201", description = "개인정보 수정 성공"),
-                @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
-                @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
-                @ApiResponse(responseCode = "404", description = "사용자 정보를 찾을 수 없음")
+                @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content),
+                @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+                @ApiResponse(responseCode = "404", description = "사용자 정보를 찾을 수 없음", content = @Content)
             })
     @PostMapping
     public ResponseEntity<Void> updatePersonalInfo(

--- a/src/main/java/aegis/server/domain/member/controller/MemberController.java
+++ b/src/main/java/aegis/server/domain/member/controller/MemberController.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import org.springframework.http.HttpStatus;
@@ -29,9 +28,10 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    @Operation(summary = "개인정보 조회", description = "로그인한 사용자의 개인정보를 조회합니다.")
-    @ApiResponses(
-            value = {
+    @Operation(
+            summary = "개인정보 조회",
+            description = "로그인한 사용자의 개인정보를 조회합니다.",
+            responses = {
                 @ApiResponse(responseCode = "200", description = "개인정보 조회 성공"),
                 @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
                 @ApiResponse(responseCode = "404", description = "사용자 정보를 찾을 수 없음", content = @Content)
@@ -42,9 +42,10 @@ public class MemberController {
         return ResponseEntity.ok(memberService.getPersonalInfo(userDetails));
     }
 
-    @Operation(summary = "개인정보 수정", description = "로그인한 사용자의 개인정보를 수정합니다.")
-    @ApiResponses(
-            value = {
+    @Operation(
+            summary = "개인정보 수정",
+            description = "로그인한 사용자의 개인정보를 수정합니다.",
+            responses = {
                 @ApiResponse(responseCode = "201", description = "개인정보 수정 성공"),
                 @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content),
                 @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),

--- a/src/main/java/aegis/server/domain/payment/controller/PaymentController.java
+++ b/src/main/java/aegis/server/domain/payment/controller/PaymentController.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import org.springframework.http.HttpStatus;
@@ -27,9 +26,10 @@ public class PaymentController {
 
     private final PaymentService paymentService;
 
-    @Operation(summary = "결제 요청 생성/수정", description = "쿠폰을 사용하여 결제 요청을 생성하거나 수정합니다.")
-    @ApiResponses(
-            value = {
+    @Operation(
+            summary = "결제 요청 생성/수정",
+            description = "쿠폰을 사용하여 결제 요청을 생성하거나 수정합니다.",
+            responses = {
                 @ApiResponse(responseCode = "201", description = "결제 요청 생성/수정 성공"),
                 @ApiResponse(responseCode = "400", description = "쿠폰이 해당 사용자에게 발급되지 않음", content = @Content),
                 @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
@@ -43,9 +43,10 @@ public class PaymentController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @Operation(summary = "결제 상태 조회", description = "로그인한 사용자의 결제 상태를 조회합니다.")
-    @ApiResponses(
-            value = {
+    @Operation(
+            summary = "결제 상태 조회",
+            description = "로그인한 사용자의 결제 상태를 조회합니다.",
+            responses = {
                 @ApiResponse(responseCode = "200", description = "결제 상태 조회 성공"),
                 @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
                 @ApiResponse(responseCode = "404", description = "사용자 정보를 찾을 수 없음", content = @Content)

--- a/src/main/java/aegis/server/domain/payment/controller/PaymentController.java
+++ b/src/main/java/aegis/server/domain/payment/controller/PaymentController.java
@@ -2,6 +2,7 @@ package aegis.server.domain.payment.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -30,10 +31,10 @@ public class PaymentController {
     @ApiResponses(
             value = {
                 @ApiResponse(responseCode = "201", description = "결제 요청 생성/수정 성공"),
-                @ApiResponse(responseCode = "400", description = "쿠폰이 해당 사용자에게 발급되지 않음"),
-                @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
-                @ApiResponse(responseCode = "404", description = "학생 정보 또는 결제 정보를 찾을 수 없음"),
-                @ApiResponse(responseCode = "409", description = "이미 완료된 결제이거나 초과 결제 상태")
+                @ApiResponse(responseCode = "400", description = "쿠폰이 해당 사용자에게 발급되지 않음", content = @Content),
+                @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+                @ApiResponse(responseCode = "404", description = "학생 정보 또는 결제 정보를 찾을 수 없음", content = @Content),
+                @ApiResponse(responseCode = "409", description = "이미 완료된 결제이거나 초과 결제 상태", content = @Content)
             })
     @PostMapping
     public ResponseEntity<Void> createOrUpdatePendingPayment(
@@ -46,8 +47,8 @@ public class PaymentController {
     @ApiResponses(
             value = {
                 @ApiResponse(responseCode = "200", description = "결제 상태 조회 성공"),
-                @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
-                @ApiResponse(responseCode = "404", description = "사용자 정보를 찾을 수 없음")
+                @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+                @ApiResponse(responseCode = "404", description = "사용자 정보를 찾을 수 없음", content = @Content)
             })
     @GetMapping("/status")
     public ResponseEntity<PaymentStatusResponse> checkPaymentStatus(

--- a/src/main/java/aegis/server/domain/payment/controller/TransactionController.java
+++ b/src/main/java/aegis/server/domain/payment/controller/TransactionController.java
@@ -2,6 +2,7 @@ package aegis.server.domain.payment.controller;
 
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -28,8 +29,8 @@ public class TransactionController {
     @ApiResponses(
             value = {
                 @ApiResponse(responseCode = "200", description = "거래 생성 성공"),
-                @ApiResponse(responseCode = "400", description = "거래 데이터 형식 오류"),
-                @ApiResponse(responseCode = "500", description = "거래 로그 파싱 실패 또는 데이터베이스 오류")
+                @ApiResponse(responseCode = "400", description = "거래 데이터 형식 오류", content = @Content),
+                @ApiResponse(responseCode = "500", description = "거래 로그 파싱 실패 또는 데이터베이스 오류", content = @Content)
             })
     @PostMapping
     public void createTransaction(@RequestBody String request) {

--- a/src/main/java/aegis/server/domain/payment/controller/TransactionController.java
+++ b/src/main/java/aegis/server/domain/payment/controller/TransactionController.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,9 +24,10 @@ public class TransactionController {
     private final TransactionService transactionService;
 
     @Hidden
-    @Operation(summary = "거래 생성", description = "외부 시스템에서 거래 데이터를 생성합니다. (내부 API)")
-    @ApiResponses(
-            value = {
+    @Operation(
+            summary = "거래 생성",
+            description = "외부 시스템에서 거래 데이터를 생성합니다. (내부 API)",
+            responses = {
                 @ApiResponse(responseCode = "200", description = "거래 생성 성공"),
                 @ApiResponse(responseCode = "400", description = "거래 데이터 형식 오류", content = @Content),
                 @ApiResponse(responseCode = "500", description = "거래 로그 파싱 실패 또는 데이터베이스 오류", content = @Content)

--- a/src/main/java/aegis/server/domain/survey/controller/SurveyController.java
+++ b/src/main/java/aegis/server/domain/survey/controller/SurveyController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -31,8 +32,8 @@ public class SurveyController {
     @ApiResponses(
             value = {
                 @ApiResponse(responseCode = "200", description = "설문조사 조회 성공"),
-                @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
-                @ApiResponse(responseCode = "404", description = "설문조사 답변을 찾을 수 없음")
+                @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+                @ApiResponse(responseCode = "404", description = "설문조사 답변을 찾을 수 없음", content = @Content)
             })
     @GetMapping
     public ResponseEntity<SurveyCommon> getSurvey(@Parameter(hidden = true) @LoginUser UserDetails userDetails) {
@@ -43,8 +44,8 @@ public class SurveyController {
     @ApiResponses(
             value = {
                 @ApiResponse(responseCode = "201", description = "설문조사 작성/수정 성공"),
-                @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
-                @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+                @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content),
+                @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content)
             })
     @PostMapping
     public ResponseEntity<Void> createOrUpdateSurvey(

--- a/src/main/java/aegis/server/domain/survey/controller/SurveyController.java
+++ b/src/main/java/aegis/server/domain/survey/controller/SurveyController.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import org.springframework.http.HttpStatus;
@@ -28,9 +27,10 @@ public class SurveyController {
 
     private final SurveyService surveyService;
 
-    @Operation(summary = "내 설문조사 조회", description = "로그인한 사용자의 설문조사 답변을 조회합니다.")
-    @ApiResponses(
-            value = {
+    @Operation(
+            summary = "내 설문조사 조회",
+            description = "로그인한 사용자의 설문조사 답변을 조회합니다.",
+            responses = {
                 @ApiResponse(responseCode = "200", description = "설문조사 조회 성공"),
                 @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
                 @ApiResponse(responseCode = "404", description = "설문조사 답변을 찾을 수 없음", content = @Content)
@@ -40,9 +40,10 @@ public class SurveyController {
         return ResponseEntity.ok(surveyService.getSurvey(userDetails));
     }
 
-    @Operation(summary = "설문조사 작성/수정", description = "로그인한 사용자의 설문조사 답변을 작성하거나 수정합니다.")
-    @ApiResponses(
-            value = {
+    @Operation(
+            summary = "설문조사 작성/수정",
+            description = "로그인한 사용자의 설문조사 답변을 작성하거나 수정합니다.",
+            responses = {
                 @ApiResponse(responseCode = "201", description = "설문조사 작성/수정 성공"),
                 @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content),
                 @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content)

--- a/src/main/java/aegis/server/global/security/controller/AuthController.java
+++ b/src/main/java/aegis/server/global/security/controller/AuthController.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import org.springframework.http.HttpStatus;
@@ -38,9 +37,10 @@ public class AuthController {
     private final PaymentRepository paymentRepository;
     private final MemberRepository memberRepository;
 
-    @Operation(summary = "인증 상태 확인", description = "사용자의 인증 상태와 결제 상태를 확인합니다.")
-    @ApiResponses(
-            value = {
+    @Operation(
+            summary = "인증 상태 확인",
+            description = "사용자의 인증 상태와 결제 상태를 확인합니다.",
+            responses = {
                 @ApiResponse(responseCode = "200", description = "인증 상태 확인 성공"),
                 @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
                 @ApiResponse(responseCode = "404", description = "학생 정보를 찾을 수 없음", content = @Content)
@@ -63,8 +63,10 @@ public class AuthController {
         }
     }
 
-    @Operation(summary = "비단국대 이메일 오류 페이지", description = "단국대학교 이메일이 아닌 경우 리다이렉트되는 오류 페이지입니다.")
-    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "오류 페이지 반환")})
+    @Operation(
+            summary = "비단국대 이메일 오류 페이지",
+            description = "단국대학교 이메일이 아닌 경우 리다이렉트되는 오류 페이지입니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "오류 페이지 반환")})
     @GetMapping("/auth/error/not-dku")
     public ResponseEntity<String> notDku() {
         String html =

--- a/src/main/java/aegis/server/global/security/controller/AuthController.java
+++ b/src/main/java/aegis/server/global/security/controller/AuthController.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -41,8 +42,8 @@ public class AuthController {
     @ApiResponses(
             value = {
                 @ApiResponse(responseCode = "200", description = "인증 상태 확인 성공"),
-                @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
-                @ApiResponse(responseCode = "404", description = "학생 정보를 찾을 수 없음")
+                @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+                @ApiResponse(responseCode = "404", description = "학생 정보를 찾을 수 없음", content = @Content)
             })
     @GetMapping("/auth/check")
     public ResponseEntity<AuthCheckResponse> check(@Parameter(hidden = true) @LoginUser UserDetails userDetails) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * API 문서의 Swagger/OpenAPI 응답 명세가 보다 명확하고 일관성 있게 개선되었습니다.
  * 모든 오류 응답(예: 400, 401, 404, 409, 500)에 대해 응답 본문이 없음을 명시적으로 표시합니다.
  * 실제 서비스 동작에는 영향을 주지 않으며, API 문서의 가독성과 명확성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->