### PR TITLE
refactor(BE-54): 더 이상 의미를 가지지 않는 expectedDepositorName 필드 제거

### DIFF
--- a/src/main/java/aegis/server/domain/payment/domain/Payment.java
+++ b/src/main/java/aegis/server/domain/payment/domain/Payment.java
@@ -49,12 +49,6 @@ public class Payment extends BaseEntity {
     @Column(precision = 10, scale = 0)
     private BigDecimal finalPrice;
 
-    private String expectedDepositorName;
-
-    public static String expectedDepositorName(Member member) {
-        return member.getName();
-    }
-
     public static Payment of(Member member) {
         return Payment.builder()
                 .member(member)
@@ -62,7 +56,6 @@ public class Payment extends BaseEntity {
                 .yearSemester(CURRENT_YEAR_SEMESTER)
                 .originalPrice(CLUB_DUES)
                 .finalPrice(CLUB_DUES)
-                .expectedDepositorName(expectedDepositorName(member))
                 .build();
     }
 

--- a/src/main/java/aegis/server/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/aegis/server/domain/payment/repository/PaymentRepository.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import aegis.server.domain.common.domain.YearSemester;
 import aegis.server.domain.member.domain.Member;
@@ -14,17 +16,21 @@ import static aegis.server.global.constant.Constant.CURRENT_YEAR_SEMESTER;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
-    Optional<Payment> findByMemberAndYearSemester(Member member, YearSemester yearSemester);
+    @Query("SELECT p FROM Payment p JOIN FETCH p.member WHERE p.member = :member AND p.yearSemester = :yearSemester")
+    Optional<Payment> findByMemberAndYearSemester(
+            @Param("member") Member member, @Param("yearSemester") YearSemester yearSemester);
 
     default Optional<Payment> findByMemberInCurrentYearSemester(Member member) {
         return findByMemberAndYearSemester(member, CURRENT_YEAR_SEMESTER);
     }
 
-    Optional<Payment> findByExpectedDepositorNameAndYearSemester(
-            String expectedDepositorName, YearSemester yearSemester);
+    @Query(
+            "SELECT p FROM Payment p JOIN FETCH p.member WHERE p.member.name = :memberName AND p.yearSemester = :yearSemester")
+    Optional<Payment> findByMemberNameAndYearSemester(
+            @Param("memberName") String memberName, @Param("yearSemester") YearSemester yearSemester);
 
-    default Optional<Payment> findByExpectedDepositorNameInCurrentYearSemester(String expectedDepositorName) {
-        return findByExpectedDepositorNameAndYearSemester(expectedDepositorName, CURRENT_YEAR_SEMESTER);
+    default Optional<Payment> findByMemberNameInCurrentYearSemester(String memberName) {
+        return findByMemberNameAndYearSemester(memberName, CURRENT_YEAR_SEMESTER);
     }
 
     List<Payment> findAllByStatusAndYearSemester(PaymentStatus paymentStatus, YearSemester currentYearSemester);

--- a/src/main/java/aegis/server/domain/payment/service/PaymentService.java
+++ b/src/main/java/aegis/server/domain/payment/service/PaymentService.java
@@ -46,8 +46,8 @@ public class PaymentService {
                 .findByMemberInCurrentYearSemester(member)
                 .orElseThrow(() -> new CustomException(ErrorCode.PAYMENT_NOT_FOUND));
 
-        BigDecimal currentDepositAmount =
-                transactionRepository.sumAmountByDepositorName(payment.getExpectedDepositorName());
+        BigDecimal currentDepositAmount = transactionRepository.sumAmountByDepositorName(
+                payment.getMember().getName());
 
         return PaymentStatusResponse.from(payment, currentDepositAmount);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 결제 처리 및 조회 시 '예상 입금자명' 대신 '회원 이름'을 일관되게 사용하도록 변경되었습니다.
  * 관련 메서드 및 로그 메시지가 '회원 이름' 기준으로 수정되었습니다.

* **테스트**
  * 테스트 코드에서 '예상 입금자명' 필드가 제거되고, 직접적으로 '회원 이름'을 사용하도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->