### PR TITLE
feat(BE-59): GUEST 역할 추가와 강등 기능 추가

### DIFF
--- a/src/main/java/aegis/server/domain/member/controller/AdminMemberController.java
+++ b/src/main/java/aegis/server/domain/member/controller/AdminMemberController.java
@@ -1,0 +1,36 @@
+package aegis.server.domain.member.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import lombok.RequiredArgsConstructor;
+
+import aegis.server.domain.member.dto.response.MemberDemoteResponse;
+import aegis.server.domain.member.service.MemberService;
+
+@Tag(name = "Admin Member", description = "관리자 회원 관리 API")
+@RestController
+@RequestMapping("/admin/members")
+@RequiredArgsConstructor
+public class AdminMemberController {
+
+    private final MemberService memberService;
+
+    @Operation(
+            summary = "회원 강등",
+            description = "현재 학기 회비를 납부하지 않은 회원들을 ROLE_GUEST로 강등합니다. 관리자(ROLE_ADMIN)는 강등 대상에서 제외됩니다.",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "회원 강등 성공"),
+                @ApiResponse(responseCode = "403", description = "관리자 권한 필요", content = @Content)
+            })
+    @PostMapping("/demote")
+    public ResponseEntity<MemberDemoteResponse> demoteMembersForCurrentSemester() {
+        MemberDemoteResponse response = memberService.demoteMembersForCurrentSemester();
+        return ResponseEntity.ok().body(response);
+    }
+}

--- a/src/main/java/aegis/server/domain/member/domain/Member.java
+++ b/src/main/java/aegis/server/domain/member/domain/Member.java
@@ -78,4 +78,16 @@ public class Member extends BaseEntity {
     public void updateDiscordId(String discordId) {
         this.discordId = discordId;
     }
+
+    public boolean isGuest() {
+        return Role.GUEST.equals(this.role);
+    }
+
+    public void promoteToUser() {
+        this.role = Role.USER;
+    }
+
+    public void demoteToGuest() {
+        this.role = Role.GUEST;
+    }
 }

--- a/src/main/java/aegis/server/domain/member/domain/Role.java
+++ b/src/main/java/aegis/server/domain/member/domain/Role.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum Role {
+    GUEST("ROLE_GUEST"),
     USER("ROLE_USER"),
     ADMIN("ROLE_ADMIN");
 

--- a/src/main/java/aegis/server/domain/member/dto/response/MemberDemoteResponse.java
+++ b/src/main/java/aegis/server/domain/member/dto/response/MemberDemoteResponse.java
@@ -1,0 +1,10 @@
+package aegis.server.domain.member.dto.response;
+
+import java.util.List;
+
+public record MemberDemoteResponse(List<String> demotedMemberStudentIds) {
+
+    public static MemberDemoteResponse of(List<String> demotedMemberStudentIds) {
+        return new MemberDemoteResponse(demotedMemberStudentIds);
+    }
+}

--- a/src/main/java/aegis/server/domain/member/repository/MemberRepository.java
+++ b/src/main/java/aegis/server/domain/member/repository/MemberRepository.java
@@ -1,11 +1,18 @@
 package aegis.server.domain.member.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import aegis.server.domain.member.domain.Member;
+import aegis.server.domain.member.domain.Role;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByOidcId(String oidcId);
+
+    @Query("SELECT m FROM Member m WHERE m.role != :role AND m.id NOT IN :excludedIds")
+    List<Member> findAllByRoleNotAndIdNotIn(@Param("role") Role role, @Param("excludedIds") List<Long> excludedIds);
 }

--- a/src/main/java/aegis/server/domain/member/service/MemberService.java
+++ b/src/main/java/aegis/server/domain/member/service/MemberService.java
@@ -1,17 +1,26 @@
 package aegis.server.domain.member.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
 import aegis.server.domain.member.domain.Member;
+import aegis.server.domain.member.domain.Role;
 import aegis.server.domain.member.dto.request.PersonalInfoUpdateRequest;
+import aegis.server.domain.member.dto.response.MemberDemoteResponse;
 import aegis.server.domain.member.dto.response.PersonalInfoResponse;
 import aegis.server.domain.member.repository.MemberRepository;
+import aegis.server.domain.payment.domain.Payment;
+import aegis.server.domain.payment.domain.PaymentStatus;
+import aegis.server.domain.payment.repository.PaymentRepository;
 import aegis.server.global.exception.CustomException;
 import aegis.server.global.exception.ErrorCode;
 import aegis.server.global.security.oidc.UserDetails;
+
+import static aegis.server.global.constant.Constant.CURRENT_YEAR_SEMESTER;
 
 @Service
 @Transactional(readOnly = true)
@@ -19,6 +28,7 @@ import aegis.server.global.security.oidc.UserDetails;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final PaymentRepository paymentRepository;
 
     public PersonalInfoResponse getPersonalInfo(UserDetails userDetails) {
         Member member = memberRepository
@@ -41,5 +51,24 @@ public class MemberService {
                 request.grade(),
                 request.birthDate(),
                 request.gender());
+    }
+
+    @Transactional
+    public MemberDemoteResponse demoteMembersForCurrentSemester() {
+        List<Payment> completedPayments =
+                paymentRepository.findAllByStatusAndYearSemester(PaymentStatus.COMPLETED, CURRENT_YEAR_SEMESTER);
+
+        List<Long> paidMemberIds = completedPayments.stream()
+                .map(payment -> payment.getMember().getId())
+                .toList();
+
+        List<Member> unpaidMembers = memberRepository.findAllByRoleNotAndIdNotIn(Role.ADMIN, paidMemberIds);
+
+        List<String> demotedMemberStudentIds =
+                unpaidMembers.stream().map(Member::getStudentId).toList();
+
+        unpaidMembers.forEach(Member::demoteToGuest);
+
+        return MemberDemoteResponse.of(demotedMemberStudentIds);
     }
 }

--- a/src/main/java/aegis/server/domain/member/service/listener/MemberEventListener.java
+++ b/src/main/java/aegis/server/domain/member/service/listener/MemberEventListener.java
@@ -1,0 +1,48 @@
+package aegis.server.domain.member.service.listener;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import aegis.server.domain.member.domain.Member;
+import aegis.server.domain.member.repository.MemberRepository;
+import aegis.server.domain.payment.domain.event.PaymentCompletedEvent;
+import aegis.server.domain.payment.dto.internal.PaymentInfo;
+import aegis.server.global.exception.CustomException;
+import aegis.server.global.exception.ErrorCode;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MemberEventListener {
+
+    private final MemberRepository memberRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handlePaymentCompletedEvent(PaymentCompletedEvent event) {
+        PaymentInfo paymentInfo = event.paymentInfo();
+
+        Member member = memberRepository
+                .findById(paymentInfo.memberId())
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        promoteToUserIfGuest(member);
+    }
+
+    private void promoteToUserIfGuest(Member member) {
+        if (member.isGuest()) {
+            member.promoteToUser();
+            memberRepository.save(member);
+            log.info(
+                    "[MemberEventListener] 회비 납부 완료로 인한 자동 승격: memberId={}, memberName={}, GUEST → USER",
+                    member.getId(),
+                    member.getName());
+        }
+    }
+}

--- a/src/test/java/aegis/server/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/aegis/server/domain/member/service/MemberServiceTest.java
@@ -8,7 +8,11 @@ import org.junit.jupiter.api.Test;
 
 import aegis.server.domain.member.domain.*;
 import aegis.server.domain.member.dto.request.PersonalInfoUpdateRequest;
+import aegis.server.domain.member.dto.response.MemberDemoteResponse;
 import aegis.server.domain.member.repository.MemberRepository;
+import aegis.server.domain.payment.domain.Payment;
+import aegis.server.domain.payment.domain.PaymentStatus;
+import aegis.server.domain.payment.repository.PaymentRepository;
 import aegis.server.global.exception.CustomException;
 import aegis.server.global.exception.ErrorCode;
 import aegis.server.global.security.oidc.UserDetails;
@@ -16,6 +20,7 @@ import aegis.server.helper.IntegrationTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MemberServiceTest extends IntegrationTest {
 
@@ -24,6 +29,9 @@ class MemberServiceTest extends IntegrationTest {
 
     @Autowired
     MemberRepository memberRepository;
+
+    @Autowired
+    PaymentRepository paymentRepository;
 
     private final PersonalInfoUpdateRequest personalInfoUpdateRequest = new PersonalInfoUpdateRequest(
             "010-1234-5678", "32000000", Department.SW융합대학_컴퓨터공학과, Grade.THREE, "010101", Gender.MALE);
@@ -63,6 +71,82 @@ class MemberServiceTest extends IntegrationTest {
                     CustomException.class,
                     () -> memberService.updatePersonalInfo(userDetails, personalInfoUpdateRequest));
             assertEquals(ErrorCode.MEMBER_NOT_FOUND, exception.getErrorCode());
+        }
+    }
+
+    @Nested
+    class 회원_강등 {
+
+        @Test
+        void 현재_학기_미납_회원을_강등한다() {
+            // given
+            Member userMember = createMember();
+            userMember.promoteToUser();
+            memberRepository.save(userMember);
+
+            // when
+            MemberDemoteResponse response = memberService.demoteMembersForCurrentSemester();
+
+            // then
+            Member updatedMember = memberRepository.findById(userMember.getId()).get();
+            assertTrue(updatedMember.isGuest());
+            assertTrue(response.demotedMemberStudentIds().contains(userMember.getStudentId()));
+        }
+
+        @Test
+        void ADMIN_역할은_강등하지_않는다() {
+            // given
+            Member adminMember = createMember();
+            ReflectionTestUtils.setField(adminMember, "role", Role.ADMIN);
+            memberRepository.save(adminMember);
+
+            // when
+            MemberDemoteResponse response = memberService.demoteMembersForCurrentSemester();
+
+            // then
+            Member updatedMember =
+                    memberRepository.findById(adminMember.getId()).get();
+            assertEquals(Role.ADMIN, updatedMember.getRole());
+            assertTrue(response.demotedMemberStudentIds().isEmpty());
+        }
+
+        @Test
+        void 결제_완료된_회원은_강등하지_않는다() {
+            // given
+            Member userMember = createMember();
+            userMember.promoteToUser();
+            memberRepository.save(userMember);
+
+            Payment payment = Payment.of(userMember);
+            payment.confirmPayment(PaymentStatus.COMPLETED);
+            paymentRepository.save(payment);
+
+            // when
+            MemberDemoteResponse response = memberService.demoteMembersForCurrentSemester();
+
+            // then
+            Member updatedMember = memberRepository.findById(userMember.getId()).get();
+            assertEquals(Role.USER, updatedMember.getRole());
+            assertTrue(response.demotedMemberStudentIds().isEmpty());
+        }
+
+        @Test
+        void 강등된_회원의_학번_목록을_반환한다() {
+            // given
+            Member userMember1 = createMember();
+            Member userMember2 = createMember();
+            userMember1.promoteToUser();
+            userMember2.promoteToUser();
+            memberRepository.save(userMember1);
+            memberRepository.save(userMember2);
+
+            // when
+            MemberDemoteResponse response = memberService.demoteMembersForCurrentSemester();
+
+            // then
+            assertEquals(2, response.demotedMemberStudentIds().size());
+            assertTrue(response.demotedMemberStudentIds().contains(userMember1.getStudentId()));
+            assertTrue(response.demotedMemberStudentIds().contains(userMember2.getStudentId()));
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 관리자가 현재 학기 회비 미납 회원을 게스트로 일괄 강등할 수 있는 엔드포인트가 추가되었습니다.
  * 결제 완료 시 게스트 회원이 자동으로 일반 회원(USER)으로 승격됩니다.

* **버그 수정**
  * 없음

* **테스트**
  * 회원 강등 및 결제 후 자동 승격 기능에 대한 테스트가 추가되었습니다.

* **기타**
  * 게스트 역할(ROLE_GUEST)이 새롭게 도입되었습니다.  
  * 강등된 회원의 학번 목록을 반환하는 응답 구조가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->