### PR TITLE
refactor: 2025년 2학기로 전환할 수 있도록 연관관계 수정

### DIFF
--- a/src/main/java/aegis/server/domain/common/domain/YearSemester.java
+++ b/src/main/java/aegis/server/domain/common/domain/YearSemester.java
@@ -3,10 +3,13 @@ package aegis.server.domain.common.domain;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.time.Year;
+
 @Getter
 @RequiredArgsConstructor
 public enum YearSemester {
-    YEAR_SEMESTER_2025_1("2025-1");
+    YEAR_SEMESTER_2025_1("2025-1"),
+    YEAR_SEMESTER_2025_2("2025-2");
 
     private final String value;
 }

--- a/src/main/java/aegis/server/domain/payment/domain/Payment.java
+++ b/src/main/java/aegis/server/domain/payment/domain/Payment.java
@@ -27,7 +27,7 @@ public class Payment extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/src/main/java/aegis/server/global/constant/Constant.java
+++ b/src/main/java/aegis/server/global/constant/Constant.java
@@ -9,7 +9,7 @@ public class Constant {
 
     public static final BigDecimal CLUB_DUES = BigDecimal.valueOf(15000);
 
-    public static final YearSemester CURRENT_YEAR_SEMESTER = YearSemester.YEAR_SEMESTER_2025_1;
+    public static final YearSemester CURRENT_YEAR_SEMESTER = YearSemester.YEAR_SEMESTER_2025_2;
 
     public static final String PROD_CLIENT_JOIN_URL = "https://join.dkuaegis.org";
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 2025년 2학기(`2025-2`)가 학기 선택지에 추가되었습니다.

* **버그 수정**
  * 결제와 회원의 관계가 1:1에서 다대일로 변경되어, 한 회원이 여러 결제를 가질 수 있게 되었습니다.

* **기타**
  * 기본 학기가 2025년 2학기로 변경되었습니다.
  * 결제 서비스의 학기별 결제 생성 관련 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->