### PR TITLE
chore(BE-89): PostgreSQL testcontainers 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,8 @@ dependencies {
     testImplementation 'com.github.fppt:jedis-mock:1.1.11'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:postgresql'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     compileOnly 'org.projectlombok:lombok'

--- a/src/test/java/aegis/server/helper/DatabaseCleaner.java
+++ b/src/test/java/aegis/server/helper/DatabaseCleaner.java
@@ -37,11 +37,9 @@ public class DatabaseCleaner implements InitializingBean {
 
     private void doClean(Connection connection) throws SQLException {
         try (Statement statement = connection.createStatement()) {
-            statement.executeUpdate("SET REFERENTIAL_INTEGRITY FALSE");
             for (String tableName : tableNames) {
-                statement.executeUpdate("TRUNCATE TABLE " + tableName + " RESTART IDENTITY");
+                statement.executeUpdate("TRUNCATE TABLE " + tableName + " RESTART IDENTITY CASCADE");
             }
-            statement.executeUpdate("SET REFERENTIAL_INTEGRITY TRUE");
         }
     }
 }

--- a/src/test/java/aegis/server/helper/IntegrationTest.java
+++ b/src/test/java/aegis/server/helper/IntegrationTest.java
@@ -11,6 +11,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import aegis.server.domain.activity.domain.Activity;
 import aegis.server.domain.activity.repository.ActivityRepository;
@@ -21,6 +22,11 @@ import aegis.server.domain.coupon.repository.IssuedCouponRepository;
 import aegis.server.domain.discord.service.listener.DiscordEventListener;
 import aegis.server.domain.member.domain.*;
 import aegis.server.domain.member.repository.MemberRepository;
+import aegis.server.domain.point.domain.PointAccount;
+import aegis.server.domain.point.domain.PointTransaction;
+import aegis.server.domain.point.domain.PointTransactionType;
+import aegis.server.domain.point.repository.PointAccountRepository;
+import aegis.server.domain.point.repository.PointTransactionRepository;
 import aegis.server.global.security.oidc.UserDetails;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -28,6 +34,7 @@ import static org.mockito.Mockito.doNothing;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@Testcontainers
 public class IntegrationTest {
 
     @Autowired
@@ -47,6 +54,12 @@ public class IntegrationTest {
 
     @Autowired
     ActivityRepository activityRepository;
+
+    @Autowired
+    PointAccountRepository pointAccountRepository;
+
+    @Autowired
+    PointTransactionRepository pointTransactionRepository;
 
     @MockitoBean
     JDA jda;
@@ -105,5 +118,22 @@ public class IntegrationTest {
         ReflectionTestUtils.setField(activity, "name", name + activity.getId());
 
         return activityRepository.save(activity);
+    }
+
+    protected PointAccount createPointAccount(Member member) {
+        return pointAccountRepository.save(PointAccount.create(member));
+    }
+
+    protected void createPointTransaction(
+            PointAccount account, PointTransactionType type, BigDecimal amount, String reason) {
+        pointTransactionRepository.save(PointTransaction.create(account, type, amount, reason));
+    }
+
+    protected void createEarnTransaction(PointAccount account, BigDecimal amount, String reason) {
+        createPointTransaction(account, PointTransactionType.EARN, amount, reason);
+    }
+
+    protected void createSpendTransaction(PointAccount account, BigDecimal amount, String reason) {
+        createPointTransaction(account, PointTransactionType.SPEND, amount, reason);
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -3,8 +3,14 @@ spring:
     activate:
       on-profile: test
   datasource:
-    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;
-    driver-class-name: org.h2.Driver
+    url: jdbc:tc:postgresql:17-alpine://test/testdb
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
   security:
     oauth2:
       client:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * PostgreSQL Testcontainers를 활용한 통합 테스트 환경이 추가되었습니다.
  * 포인트 계정 및 트랜잭션 관련 테스트 헬퍼 메서드가 확장되었습니다.
  * 데이터베이스 정리 로직이 개선되어, CASCADE 옵션을 사용해 참조 무결성 관리가 간소화되었습니다.
  * 테스트 데이터베이스 구성이 H2에서 PostgreSQL 컨테이너로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->