### PR TITLE
refactor(BE-79): AntPathRequestMatcher 대신 PathPatternRequestMatcher 사용

### DIFF
--- a/src/main/java/aegis/server/global/security/oidc/RefererFilter.java
+++ b/src/main/java/aegis/server/global/security/oidc/RefererFilter.java
@@ -11,7 +11,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -24,7 +24,8 @@ import static aegis.server.global.constant.Constant.ALLOWED_CLIENT_URLS;
 @Component
 public class RefererFilter extends OncePerRequestFilter {
 
-    private final RequestMatcher authorizationRequestMatcher = new AntPathRequestMatcher("/oauth2/authorization/**");
+    private final RequestMatcher authorizationRequestMatcher =
+            PathPatternRequestMatcher.withDefaults().matcher("/oauth2/authorization/**");
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 인증 요청 경로 매칭 방식을 개선하여 더욱 일관된 경로 인식이 가능하도록 변경되었습니다.  


<!-- end of auto-generated comment: release notes by coderabbit.ai -->