### PR TITLE
refactor(BE-192): 본인 쿠폰 조회 시 사용한 쿠폰도 나오도록 변경

### DIFF
--- a/src/main/java/aegis/server/domain/coupon/controller/CouponController.java
+++ b/src/main/java/aegis/server/domain/coupon/controller/CouponController.java
@@ -32,15 +32,15 @@ public class CouponController {
 
     @Operation(
             summary = "내 발급된 쿠폰 조회",
-            description = "로그인한 사용자의 유효한 발급된 쿠폰을 모두 조회합니다.",
+            description = "로그인한 사용자의 모든 발급된 쿠폰을 조회합니다.",
             responses = {
                 @ApiResponse(responseCode = "200", description = "쿠폰 조회 성공"),
                 @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content)
             })
-    @GetMapping("/issued/me")
-    public ResponseEntity<List<IssuedCouponResponse>> getMyAllValidIssuedCoupon(
+    @GetMapping("/me")
+    public ResponseEntity<List<IssuedCouponResponse>> getMyAllIssuedCoupon(
             @Parameter(hidden = true) @LoginUser UserDetails userDetails) {
-        List<IssuedCouponResponse> responses = couponService.findMyAllValidIssuedCoupons(userDetails);
+        List<IssuedCouponResponse> responses = couponService.findMyAllIssuedCoupons(userDetails);
         return ResponseEntity.ok().body(responses);
     }
 

--- a/src/main/java/aegis/server/domain/coupon/dto/response/IssuedCouponResponse.java
+++ b/src/main/java/aegis/server/domain/coupon/dto/response/IssuedCouponResponse.java
@@ -6,13 +6,19 @@ import java.time.LocalDateTime;
 import aegis.server.domain.coupon.domain.IssuedCoupon;
 
 public record IssuedCouponResponse(
-        Long issuedCouponId, Long memberId, String couponName, BigDecimal discountAmount, LocalDateTime createdAt) {
+        Long issuedCouponId,
+        Long memberId,
+        String couponName,
+        BigDecimal discountAmount,
+        Boolean isValid,
+        LocalDateTime createdAt) {
     public static IssuedCouponResponse from(IssuedCoupon issuedCoupon) {
         return new IssuedCouponResponse(
                 issuedCoupon.getId(),
                 issuedCoupon.getMember().getId(),
                 issuedCoupon.getCoupon().getCouponName(),
                 issuedCoupon.getCoupon().getDiscountAmount(),
+                issuedCoupon.getIsValid(),
                 issuedCoupon.getCreatedAt());
     }
 }

--- a/src/main/java/aegis/server/domain/coupon/repository/IssuedCouponRepository.java
+++ b/src/main/java/aegis/server/domain/coupon/repository/IssuedCouponRepository.java
@@ -4,12 +4,15 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import aegis.server.domain.coupon.domain.IssuedCoupon;
 import aegis.server.domain.member.domain.Member;
 
 public interface IssuedCouponRepository extends JpaRepository<IssuedCoupon, Long> {
-    List<IssuedCoupon> findAllByMember(Member member);
+
+    @Query("SELECT ic FROM IssuedCoupon ic JOIN FETCH ic.member JOIN FETCH ic.coupon WHERE ic.member = :member")
+    List<IssuedCoupon> findAllByMemberWithCoupon(@Param("member") Member member);
 
     @Query(
             "SELECT COUNT(ic) FROM IssuedCoupon ic WHERE ic.id IN :ids AND ic.member.id = :memberId AND ic.isValid = true")

--- a/src/main/java/aegis/server/domain/coupon/service/CouponService.java
+++ b/src/main/java/aegis/server/domain/coupon/service/CouponService.java
@@ -80,13 +80,12 @@ public class CouponService {
                 .toList();
     }
 
-    public List<IssuedCouponResponse> findMyAllValidIssuedCoupons(UserDetails userDetails) {
+    public List<IssuedCouponResponse> findMyAllIssuedCoupons(UserDetails userDetails) {
         Member member = memberRepository
                 .findById(userDetails.getMemberId())
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
-        return issuedCouponRepository.findAllByMember(member).stream()
-                .filter(IssuedCoupon::getIsValid)
+        return issuedCouponRepository.findAllByMemberWithCoupon(member).stream()
                 .map(IssuedCouponResponse::from)
                 .toList();
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능/개선
  - 내 쿠폰 조회 시 유효 쿠폰만이 아닌 모든 발급 쿠폰을 반환합니다.
  - 응답에 쿠폰의 유효 여부(isValid) 필드가 포함되어 쿠폰 상태를 한눈에 확인할 수 있습니다.
  - API 경로가 /coupons/issued/me에서 /coupons/me로 변경되었습니다. 클라이언트 호출 경로를 업데이트하세요.

- 테스트
  - 쿠폰 조회·발급, 쿠폰 코드 발급·사용, 삭제 등 시나리오에 대한 테스트가 대폭 보강되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->