### PR TITLE
refactor(BE-210): 설문조사가 한 학기에 대해서만 생성될 수 있던 설계 수정

### DIFF
--- a/src/main/java/aegis/server/domain/googlesheets/service/GoogleSheetsService.java
+++ b/src/main/java/aegis/server/domain/googlesheets/service/GoogleSheetsService.java
@@ -35,7 +35,7 @@ public class GoogleSheetsService {
 
     public void addMemberRegistration(Member member, PaymentInfo paymentInfo) throws IOException {
         Survey survey = surveyRepository
-                .findByMember(member)
+                .findByMemberIdInCurrentYearSemester(member.getId())
                 .orElseThrow(() -> new CustomException(ErrorCode.SURVEY_NOT_FOUND));
 
         ImportData importData = new ImportData(

--- a/src/main/java/aegis/server/domain/survey/domain/Survey.java
+++ b/src/main/java/aegis/server/domain/survey/domain/Survey.java
@@ -5,7 +5,10 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import aegis.server.domain.common.domain.BaseEntity;
+import aegis.server.domain.common.domain.YearSemester;
 import aegis.server.domain.member.domain.Member;
+
+import static aegis.server.global.constant.Constant.CURRENT_YEAR_SEMESTER;
 
 @Entity
 @Getter
@@ -19,9 +22,12 @@ public class Survey extends BaseEntity {
     @Column(name = "survey_id")
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @Enumerated(EnumType.STRING)
+    private YearSemester yearSemester;
 
     @Enumerated(EnumType.STRING)
     private AcquisitionType acquisitionType;
@@ -32,6 +38,7 @@ public class Survey extends BaseEntity {
     public static Survey create(Member member, AcquisitionType acquisitionType, String joinReason) {
         return Survey.builder()
                 .member(member)
+                .yearSemester(CURRENT_YEAR_SEMESTER)
                 .acquisitionType(acquisitionType)
                 .joinReason(joinReason)
                 .build();

--- a/src/main/java/aegis/server/domain/survey/repository/SurveyRepository.java
+++ b/src/main/java/aegis/server/domain/survey/repository/SurveyRepository.java
@@ -1,15 +1,21 @@
 package aegis.server.domain.survey.repository;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
-import aegis.server.domain.member.domain.Member;
+import aegis.server.domain.common.domain.YearSemester;
 import aegis.server.domain.survey.domain.Survey;
 
-public interface SurveyRepository extends JpaRepository<Survey, Long> {
-    Optional<Survey> findByMember(Member member);
+import static aegis.server.global.constant.Constant.CURRENT_YEAR_SEMESTER;
 
-    List<Survey> findByMemberIn(List<Member> members);
+public interface SurveyRepository extends JpaRepository<Survey, Long> {
+
+    @Query("select s from Survey s where s.member.id = :memberId and s.yearSemester = :yearSemester")
+    Optional<Survey> findByMemberIdAndYearSemester(Long memberId, YearSemester yearSemester);
+
+    default Optional<Survey> findByMemberIdInCurrentYearSemester(Long memberId) {
+        return findByMemberIdAndYearSemester(memberId, CURRENT_YEAR_SEMESTER);
+    }
 }

--- a/src/main/java/aegis/server/domain/survey/service/SurveyService.java
+++ b/src/main/java/aegis/server/domain/survey/service/SurveyService.java
@@ -23,9 +23,8 @@ public class SurveyService {
     private final MemberRepository memberRepository;
 
     public SurveyCommon getSurvey(UserDetails userDetails) {
-        Member member = findMemberById(userDetails.getMemberId());
         Survey survey = surveyRepository
-                .findByMember(member)
+                .findByMemberIdInCurrentYearSemester(userDetails.getMemberId())
                 .orElseThrow(() -> new CustomException(ErrorCode.SURVEY_NOT_FOUND));
 
         return SurveyCommon.from(survey);
@@ -35,7 +34,7 @@ public class SurveyService {
     public void createOrUpdateSurvey(UserDetails userDetails, SurveyCommon surveyCommon) {
         Member member = findMemberById(userDetails.getMemberId());
         surveyRepository
-                .findByMember(member)
+                .findByMemberIdInCurrentYearSemester(userDetails.getMemberId())
                 .ifPresentOrElse(
                         survey -> survey.update(surveyCommon.acquisitionType(), surveyCommon.joinReason()),
                         () -> surveyRepository.save(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  * 설문이 학기별로 관리됩니다. 학기가 바뀌면 이전 학기 설문과 분리되며, 새 학기에는 새 설문을 작성하게 됩니다.
* 개선 사항
  * 설문 조회가 현재 학기 기준으로 동작하여, 동일 회원이라도 학기 전환 시 기록이 혼동되지 않습니다.
  * 회원 등록 과정에서 현재 학기 설문을 우선 사용해 처리 안정성을 높였습니다.
* 버그 수정
  * 새 학기 시작 시 기존 설문을 찾지 못하는 경우의 예외 처리 일관성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->