### PR TITLE
feat(BE-222): 동명이인이 생성한 결제가 모두 PENDING인 상태에서 입금할 경우 NameConflictEvent 발행

### DIFF
--- a/src/main/java/aegis/server/domain/discord/service/listener/DiscordEventListener.java
+++ b/src/main/java/aegis/server/domain/discord/service/listener/DiscordEventListener.java
@@ -19,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import aegis.server.domain.member.domain.Member;
 import aegis.server.domain.member.repository.MemberRepository;
 import aegis.server.domain.payment.domain.event.MismatchEvent;
+import aegis.server.domain.payment.domain.event.NameConflictEvent;
 import aegis.server.domain.payment.domain.event.PaymentCompletedEvent;
 import aegis.server.global.exception.CustomException;
 import aegis.server.global.exception.ErrorCode;
@@ -78,6 +79,18 @@ public class DiscordEventListener {
                         event.transactionInfo().id(),
                         event.transactionInfo().depositorName(),
                         event.transactionInfo().amount()))
+                .queue();
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleNameConflictEvent(NameConflictEvent event) {
+        alarmChannel()
+                .sendMessage(String.format(
+                        "[NAME_CONFLICT]\n동명이인 결제 충돌\nTX ID: %s\n입금자명: %s\n입금 금액: %s\n해당 회원 ID: %s",
+                        event.transactionInfo().id(),
+                        event.transactionInfo().depositorName(),
+                        event.transactionInfo().amount(),
+                        event.memberIds()))
                 .queue();
     }
 

--- a/src/main/java/aegis/server/domain/payment/domain/event/NameConflictEvent.java
+++ b/src/main/java/aegis/server/domain/payment/domain/event/NameConflictEvent.java
@@ -1,0 +1,7 @@
+package aegis.server.domain.payment.domain.event;
+
+import java.util.List;
+
+import aegis.server.domain.payment.dto.internal.TransactionInfo;
+
+public record NameConflictEvent(TransactionInfo transactionInfo, List<Long> memberIds) {}

--- a/src/main/java/aegis/server/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/aegis/server/domain/payment/repository/PaymentRepository.java
@@ -57,6 +57,16 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
                 memberName, finalPrice, CURRENT_YEAR_SEMESTER, PaymentStatus.PENDING);
     }
 
+    @Query(
+            "SELECT p FROM Payment p WHERE p.member.name = :memberName AND p.finalPrice = :finalPrice AND p.yearSemester = :yearSemester AND p.status = :status")
+    List<Payment> findAllByMemberNameAndFinalPriceAndYearSemesterAndStatus(
+            String memberName, BigDecimal finalPrice, YearSemester yearSemester, PaymentStatus status);
+
+    default List<Payment> findAllPendingPaymentsForCurrentSemester(String memberName, BigDecimal finalPrice) {
+        return findAllByMemberNameAndFinalPriceAndYearSemesterAndStatus(
+                memberName, finalPrice, CURRENT_YEAR_SEMESTER, PaymentStatus.PENDING);
+    }
+
     @Query("SELECT COUNT(p) FROM Payment p WHERE p.yearSemester = :yearSemester AND p.status = :status")
     long countByYearSemesterAndStatus(YearSemester yearSemester, PaymentStatus status);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 동명이인 결제 충돌 감지 및 알림: 동일한 이름·금액 입금이 감지되면 경고를 알림 채널로 전송하고 자동 매칭을 보류(PENDING 유지)하여 오지급을 방지합니다.

- 테스트
  - 동명이인 시나리오에 대한 통합 테스트 추가로 결제 처리 안정성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->