### PR TITLE
feat(BE-255): 회비 미납부 회원 디스코드 역할 제거 API 추가

### DIFF
--- a/src/main/java/aegis/server/domain/discord/controller/AdminDiscordController.java
+++ b/src/main/java/aegis/server/domain/discord/controller/AdminDiscordController.java
@@ -1,0 +1,39 @@
+package aegis.server.domain.discord.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+import aegis.server.domain.discord.dto.response.DiscordDemoteResponse;
+import aegis.server.domain.discord.service.AdminDiscordService;
+
+@Tag(name = "Admin Discord", description = "관리자 디스코드 권한 관리 API")
+@RestController
+@RequestMapping("/admin/discord")
+@RequiredArgsConstructor
+public class AdminDiscordController {
+
+    private final AdminDiscordService adminDiscordService;
+
+    @Operation(
+            summary = "디스코드 역할 강등",
+            description = "현재 학기 회비 미납 회원에게 부여된 디스코드 완료 역할을 제거합니다. 관리자(ROLE_ADMIN)는 강등 대상에서 제외됩니다.",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "디스코드 역할 강등 성공"),
+                @ApiResponse(responseCode = "403", description = "관리자 권한 필요", content = @Content),
+                @ApiResponse(responseCode = "500", description = "디스코드 길드/역할/채널 설정 오류", content = @Content)
+            })
+    @PostMapping("/demote")
+    public ResponseEntity<DiscordDemoteResponse> demoteDiscordRolesForCurrentSemester() {
+        DiscordDemoteResponse response = adminDiscordService.demoteDiscordRolesForCurrentSemester();
+        return ResponseEntity.ok().body(response);
+    }
+}

--- a/src/main/java/aegis/server/domain/discord/dto/response/DiscordDemoteResponse.java
+++ b/src/main/java/aegis/server/domain/discord/dto/response/DiscordDemoteResponse.java
@@ -1,0 +1,9 @@
+package aegis.server.domain.discord.dto.response;
+
+import java.util.List;
+
+public record DiscordDemoteResponse(List<String> demotedMemberStudentIds) {
+    public static DiscordDemoteResponse of(List<String> demotedMemberStudentIds) {
+        return new DiscordDemoteResponse(demotedMemberStudentIds);
+    }
+}

--- a/src/main/java/aegis/server/domain/discord/service/AdminDiscordService.java
+++ b/src/main/java/aegis/server/domain/discord/service/AdminDiscordService.java
@@ -1,0 +1,84 @@
+package aegis.server.domain.discord.service;
+
+import java.util.List;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.UserSnowflake;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import aegis.server.domain.discord.dto.response.DiscordDemoteResponse;
+import aegis.server.domain.member.domain.Member;
+import aegis.server.domain.member.repository.MemberRepository;
+import aegis.server.domain.payment.domain.PaymentStatus;
+import aegis.server.domain.payment.repository.PaymentRepository;
+import aegis.server.global.exception.CustomException;
+import aegis.server.global.exception.ErrorCode;
+
+import static aegis.server.domain.member.domain.Role.ADMIN;
+import static aegis.server.global.constant.Constant.CURRENT_YEAR_SEMESTER;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AdminDiscordService {
+
+    private final JDA jda;
+    private final PaymentRepository paymentRepository;
+    private final MemberRepository memberRepository;
+
+    @Value("${discord.guild-id}")
+    private String guildId;
+
+    @Value("${discord.complete-role-id}")
+    private String completeRoleId;
+
+    public DiscordDemoteResponse demoteDiscordRolesForCurrentSemester() {
+        // 1) 현재 학기 결제 완료 회원 ID 목록
+        List<Long> paidMemberIds =
+                paymentRepository
+                        .findAllByStatusAndYearSemester(PaymentStatus.COMPLETED, CURRENT_YEAR_SEMESTER)
+                        .stream()
+                        .map(p -> p.getMember().getId())
+                        .toList();
+
+        // 2) ADMIN 제외 + 미납 회원 조회
+        List<Member> unpaidMembers = memberRepository.findAllByRoleNotAndIdNotIn(ADMIN, paidMemberIds);
+
+        // 3) 길드/역할 조회 및 유효성 검사
+        Guild guild = jda.getGuildById(guildId);
+        if (guild == null) {
+            throw new CustomException(ErrorCode.DISCORD_GUILD_NOT_FOUND);
+        }
+        Role role = guild.getRoleById(completeRoleId);
+        if (role == null) {
+            throw new CustomException(ErrorCode.DISCORD_ROLE_NOT_FOUND);
+        }
+
+        // 4) 역할 제거 실행 (비동기 처리)
+        unpaidMembers.forEach(member -> {
+            String discordId = member.getDiscordId();
+            guild.removeRoleFromMember(UserSnowflake.fromId(discordId), role)
+                    .queue(
+                            v -> {},
+                            exception -> log.warn(
+                                    "[AdminDiscordService] 역할 제거 실패: memberId={} discordId={} reason={}",
+                                    member.getId(),
+                                    discordId,
+                                    exception.toString()));
+        });
+
+        // 5) 강등 대상 학번 반환 (회원 강등 API와 응답 형태 일관)
+        List<String> demotedStudentIds =
+                unpaidMembers.stream().map(Member::getStudentId).toList();
+        return DiscordDemoteResponse.of(demotedStudentIds);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 관리용 Discord 역할 강등 엔드포인트 추가: 현 학기 미납 회원의 완료 역할을 일괄 제거.
  - 처리 결과로 강등된 회원의 학번 목록을 반환해 결과 확인 가능.
  - 길드/역할 미존재 등 상황에서 명확한 오류 응답 제공.

- 문서
  - 엔드포인트 요약과 응답 코드(200/403/500) 등 API 문서화 보강.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->