### PR TITLE
feat(BE-258): 본인이 보유한 유효한 쿠폰을 조회할 수 있는 기능 추가

### DIFF
--- a/src/main/java/aegis/server/domain/coupon/controller/CouponController.java
+++ b/src/main/java/aegis/server/domain/coupon/controller/CouponController.java
@@ -45,6 +45,20 @@ public class CouponController {
     }
 
     @Operation(
+            summary = "내 유효한 쿠폰 조회",
+            description = "로그인한 사용자의 발급된 유효 쿠폰만 조회합니다.",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "쿠폰 조회 성공"),
+                @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content)
+            })
+    @GetMapping("/me/valid")
+    public ResponseEntity<List<IssuedCouponResponse>> getMyAllValidIssuedCoupon(
+            @Parameter(hidden = true) @LoginUser UserDetails userDetails) {
+        List<IssuedCouponResponse> responses = couponService.findMyAllValidIssuedCoupons(userDetails);
+        return ResponseEntity.ok().body(responses);
+    }
+
+    @Operation(
             summary = "쿠폰 코드 사용",
             description = "쿠폰 코드를 사용하여 쿠폰을 발급받습니다.",
             responses = {

--- a/src/main/java/aegis/server/domain/coupon/repository/IssuedCouponRepository.java
+++ b/src/main/java/aegis/server/domain/coupon/repository/IssuedCouponRepository.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import aegis.server.domain.coupon.domain.IssuedCoupon;
 import aegis.server.domain.member.domain.Member;
@@ -12,7 +11,11 @@ import aegis.server.domain.member.domain.Member;
 public interface IssuedCouponRepository extends JpaRepository<IssuedCoupon, Long> {
 
     @Query("SELECT ic FROM IssuedCoupon ic JOIN FETCH ic.member JOIN FETCH ic.coupon WHERE ic.member = :member")
-    List<IssuedCoupon> findAllByMemberWithCoupon(@Param("member") Member member);
+    List<IssuedCoupon> findAllByMemberWithCoupon(Member member);
+
+    @Query("SELECT ic FROM IssuedCoupon ic JOIN FETCH ic.member JOIN FETCH ic.coupon "
+            + "WHERE ic.member = :member AND ic.isValid = true")
+    List<IssuedCoupon> findAllByMemberAndIsValidTrueWithCoupon(Member member);
 
     @Query(
             "SELECT COUNT(ic) FROM IssuedCoupon ic WHERE ic.id IN :ids AND ic.member.id = :memberId AND ic.isValid = true")

--- a/src/main/java/aegis/server/domain/coupon/service/CouponService.java
+++ b/src/main/java/aegis/server/domain/coupon/service/CouponService.java
@@ -90,6 +90,16 @@ public class CouponService {
                 .toList();
     }
 
+    public List<IssuedCouponResponse> findMyAllValidIssuedCoupons(UserDetails userDetails) {
+        Member member = memberRepository
+                .findById(userDetails.getMemberId())
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        return issuedCouponRepository.findAllByMemberAndIsValidTrueWithCoupon(member).stream()
+                .map(IssuedCouponResponse::from)
+                .toList();
+    }
+
     @Transactional
     public List<IssuedCouponResponse> createIssuedCoupon(CouponIssueRequest request) {
         Coupon coupon = couponRepository


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 새로운 기능
  * 인증된 사용자의 사용 가능한(유효) 발급 쿠폰만 조회하는 GET /coupons/me/valid 엔드포인트를 추가했습니다. 비인증 시 401, 성공 시 200과 쿠폰 목록을 반환합니다.

* 테스트
  * 유효 쿠폰 조회 서비스에 대한 단위 테스트를 추가했습니다. 사용 처리된 쿠폰은 결과에서 제외되는지, 유효 쿠폰이 없을 때 빈 목록이 반환되는지를 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->