### PR TITLE
feat(BE-270): 스터디원 목록 조회 기능 추가

### DIFF
--- a/src/main/java/aegis/server/domain/study/controller/StudyInstructorController.java
+++ b/src/main/java/aegis/server/domain/study/controller/StudyInstructorController.java
@@ -19,6 +19,7 @@ import aegis.server.domain.study.dto.request.StudyCreateUpdateRequest;
 import aegis.server.domain.study.dto.response.GeneralStudyDetail;
 import aegis.server.domain.study.dto.response.InstructorStudyApplicationReason;
 import aegis.server.domain.study.dto.response.InstructorStudyApplicationSummary;
+import aegis.server.domain.study.dto.response.InstructorStudyMemberResponse;
 import aegis.server.domain.study.service.StudyInstructorService;
 import aegis.server.global.security.annotation.LoginUser;
 import aegis.server.global.security.oidc.UserDetails;
@@ -43,6 +44,21 @@ public class StudyInstructorController {
             @PathVariable Long studyId, @Parameter(hidden = true) @LoginUser UserDetails userDetails) {
         List<InstructorStudyApplicationSummary> response =
                 studyInstructorService.findAllStudyApplications(studyId, userDetails);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+            summary = "스터디원 목록 조회",
+            description = "스터디장이 자신의 스터디의 스터디원 목록을 조회합니다.",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "스터디원 목록 조회 성공"),
+                @ApiResponse(responseCode = "403", description = "스터디장이 아님", content = @Content),
+                @ApiResponse(responseCode = "404", description = "스터디를 찾을 수 없음", content = @Content)
+            })
+    @GetMapping("/studies/{studyId}/members-instructor")
+    public ResponseEntity<List<InstructorStudyMemberResponse>> getStudyMembers(
+            @PathVariable Long studyId, @Parameter(hidden = true) @LoginUser UserDetails userDetails) {
+        List<InstructorStudyMemberResponse> response = studyInstructorService.findAllStudyMembers(studyId, userDetails);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/aegis/server/domain/study/dto/response/InstructorStudyMemberResponse.java
+++ b/src/main/java/aegis/server/domain/study/dto/response/InstructorStudyMemberResponse.java
@@ -1,0 +1,9 @@
+package aegis.server.domain.study.dto.response;
+
+import aegis.server.domain.member.domain.Member;
+
+public record InstructorStudyMemberResponse(String name, String studentId, String phoneNumber) {
+    public static InstructorStudyMemberResponse from(Member member) {
+        return new InstructorStudyMemberResponse(member.getName(), member.getStudentId(), member.getPhoneNumber());
+    }
+}

--- a/src/main/java/aegis/server/domain/study/repository/StudyMemberRepository.java
+++ b/src/main/java/aegis/server/domain/study/repository/StudyMemberRepository.java
@@ -26,6 +26,17 @@ public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> 
 
     @Query(
             """
+        SELECT sm
+        FROM StudyMember sm
+        JOIN FETCH sm.member m
+        WHERE sm.study.id = :studyId
+          AND sm.role = :role
+        ORDER BY m.name ASC
+        """)
+    List<StudyMember> findByStudyIdAndRoleWithMember(Long studyId, StudyRole role);
+
+    @Query(
+            """
         SELECT s.id
         FROM StudyMember sm
         JOIN sm.study s

--- a/src/main/java/aegis/server/domain/study/service/StudyInstructorService.java
+++ b/src/main/java/aegis/server/domain/study/service/StudyInstructorService.java
@@ -15,6 +15,7 @@ import aegis.server.domain.study.dto.request.StudyCreateUpdateRequest;
 import aegis.server.domain.study.dto.response.GeneralStudyDetail;
 import aegis.server.domain.study.dto.response.InstructorStudyApplicationReason;
 import aegis.server.domain.study.dto.response.InstructorStudyApplicationSummary;
+import aegis.server.domain.study.dto.response.InstructorStudyMemberResponse;
 import aegis.server.domain.study.repository.StudyApplicationRepository;
 import aegis.server.domain.study.repository.StudyMemberRepository;
 import aegis.server.domain.study.repository.StudyRepository;
@@ -37,6 +38,16 @@ public class StudyInstructorService {
         List<StudyApplication> studyApplications = studyApplicationRepository.findAllByStudyIdWithMember(studyId);
         return studyApplications.stream()
                 .map(InstructorStudyApplicationSummary::from)
+                .toList();
+    }
+
+    public List<InstructorStudyMemberResponse> findAllStudyMembers(Long studyId, UserDetails userDetails) {
+        validateIsStudyInstructorByStudyId(studyId, userDetails.getMemberId());
+
+        List<StudyMember> members =
+                studyMemberRepository.findByStudyIdAndRoleWithMember(studyId, StudyRole.PARTICIPANT);
+        return members.stream()
+                .map(sm -> InstructorStudyMemberResponse.from(sm.getMember()))
                 .toList();
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 강사용 스터디원 목록 조회 엔드포인트 추가. 구성원 이름, 학번, 연락처를 포함한 목록을 반환합니다.
- 문서
  - 새 엔드포인트에 대한 OpenAPI 스펙 추가(성공 200, 권한 없음 403, 스터디 없음 404).
- 테스트
  - 강사 조회 성공, 스터디원이 없을 때 빈 목록 반환, 비강사 접근 시 예외 발생 시나리오 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->