### PR TITLE
feat(BE-288): 스터디 지원 기간을 제한할 수 있도록 인터셉터 추가

### DIFF
--- a/src/main/java/aegis/server/domain/study/controller/StudyGeneralController.java
+++ b/src/main/java/aegis/server/domain/study/controller/StudyGeneralController.java
@@ -77,6 +77,7 @@ public class StudyGeneralController {
             responses = {
                 @ApiResponse(responseCode = "201", description = "스터디 참여 신청 성공"),
                 @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content),
+                @ApiResponse(responseCode = "403", description = "스터디 신청 차단됨", content = @Content),
                 @ApiResponse(responseCode = "404", description = "스터디를 찾을 수 없음", content = @Content)
             })
     @PostMapping("/studies/{studyId}/enrollment")

--- a/src/main/java/aegis/server/global/config/WebConfig.java
+++ b/src/main/java/aegis/server/global/config/WebConfig.java
@@ -10,6 +10,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import lombok.RequiredArgsConstructor;
 
 import aegis.server.global.security.annotation.LoginUserArgumentResolver;
+import aegis.server.global.security.interceptor.StudyEnrollWindowInterceptor;
 import aegis.server.global.security.interceptor.TransactionTrackInterceptor;
 
 @Configuration
@@ -18,6 +19,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     private final LoginUserArgumentResolver loginUserArgumentResolver;
     private final TransactionTrackInterceptor transactionTrackInterceptor;
+    private final StudyEnrollWindowInterceptor studyEnrollWindowInterceptor;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
@@ -27,5 +29,6 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(transactionTrackInterceptor).addPathPatterns("/internal/transaction");
+        registry.addInterceptor(studyEnrollWindowInterceptor).addPathPatterns("/studies/*/enrollment");
     }
 }

--- a/src/main/java/aegis/server/global/security/interceptor/StudyEnrollWindowInterceptor.java
+++ b/src/main/java/aegis/server/global/security/interceptor/StudyEnrollWindowInterceptor.java
@@ -1,0 +1,93 @@
+package aegis.server.global.security.interceptor;
+
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StudyEnrollWindowInterceptor implements HandlerInterceptor {
+
+    private final Clock clock;
+
+    @Value("${study.enroll-window.open-at:}")
+    private String openAtProp;
+
+    @Value("${study.enroll-window.close-at:}")
+    private String closeAtProp;
+
+    private static final List<DateTimeFormatter> SUPPORTED_FORMATS = List.of(
+            DateTimeFormatter.ISO_LOCAL_DATE_TIME, // 2025-09-20T12:00[:ss]
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"),
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"),
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm"));
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws Exception {
+        // POST 메소드만 검사
+        if (!"POST".equalsIgnoreCase(request.getMethod())) {
+            return true;
+        }
+
+        // 프로퍼티가 비어있으면 통과
+        if (isBlank(openAtProp) || isBlank(closeAtProp)) {
+            if (log.isWarnEnabled()) {
+                log.warn("스터디 참여 허용 시간이 설정되지 않았습니다. 요청을 허용합니다.");
+            }
+            return true;
+        }
+
+        LocalDateTime openAt = parseLocalDateTime(openAtProp);
+        LocalDateTime closeAt = parseLocalDateTime(closeAtProp);
+
+        if (openAt == null || closeAt == null) {
+            if (log.isWarnEnabled()) {
+                log.warn("스터디 참여 허용 시간이 올바르지 않은 형식으로 설정되었습니다. 요청을 허용합니다.");
+            }
+            return true;
+        }
+
+        ZoneId zone = clock.getZone();
+        ZonedDateTime now = ZonedDateTime.now(clock);
+        ZonedDateTime openZdt = openAt.atZone(zone);
+        ZonedDateTime closeZdt = closeAt.atZone(zone);
+
+        // 허용 구간: [openAt, closeAt) — openAt 이상, closeAt 미만만 허용
+        boolean allowed = !now.isBefore(openZdt) && now.isBefore(closeZdt);
+
+        if (!allowed) {
+            response.setStatus(HttpStatus.FORBIDDEN.value());
+            return false;
+        }
+
+        return true;
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.trim().isEmpty();
+    }
+
+    private static LocalDateTime parseLocalDateTime(String value) {
+        for (DateTimeFormatter f : SUPPORTED_FORMATS) {
+            try {
+                return LocalDateTime.parse(value, f);
+            } catch (DateTimeParseException ignored) {
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,6 +51,11 @@ payment:
 time:
   zone: Asia/Seoul
 
+study:
+  enroll-window:
+    open-at: ${STUDY_ENROLL_OPEN_AT:}
+    close-at: ${STUDY_ENROLL_CLOSE_AT:}
+
 logging:
   level:
     org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport: WARN


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 스터디 신청 가능 시간을 설정할 수 있습니다. 설정된 시간 창 내에서만 신청이 허용되며, 시간 밖에서는 신청 요청이 거절됩니다(HTTP 403).
  * 운영자는 환경변수로 신청 시작/종료 시각을 구성할 수 있습니다.
* 문서
  * 스터디 신청 API 문서에 403 Forbidden 응답 케이스를 추가하여 신청 차단 상황을 명확히 안내합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->