### PR TITLE
feat(BE-290): 포인트샵에서 상품을 뽑은 경우 관련 정보를 구글 시트에 적재하는 기능 추가

### DIFF
--- a/src/main/java/aegis/server/domain/googlesheets/dto/PointShopDrawData.java
+++ b/src/main/java/aegis/server/domain/googlesheets/dto/PointShopDrawData.java
@@ -1,0 +1,33 @@
+package aegis.server.domain.googlesheets.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import aegis.server.domain.member.domain.Member;
+import aegis.server.domain.pointshop.dto.internal.PointShopDrawInfo;
+
+public record PointShopDrawData(
+        LocalDateTime drawDateTime, Long drawHistoryId, Long memberId, String name, String phoneNumber, String item) {
+
+    public static PointShopDrawData from(PointShopDrawInfo info, Member member) {
+        return new PointShopDrawData(
+                info.createdAt(),
+                info.drawHistoryId(),
+                info.memberId(),
+                member.getName(),
+                member.getPhoneNumber(),
+                info.item().name());
+    }
+
+    public List<Object> toRowData() {
+        String formattedDateTime = drawDateTime != null ? drawDateTime.toString() : "";
+        return List.of(
+                formattedDateTime,
+                drawHistoryId,
+                memberId,
+                name,
+                phoneNumber,
+                item
+                );
+    }
+}

--- a/src/main/java/aegis/server/domain/googlesheets/service/GoogleSheetsService.java
+++ b/src/main/java/aegis/server/domain/googlesheets/service/GoogleSheetsService.java
@@ -13,8 +13,10 @@ import com.google.api.services.sheets.v4.model.ValueRange;
 import lombok.RequiredArgsConstructor;
 
 import aegis.server.domain.googlesheets.dto.ImportData;
+import aegis.server.domain.googlesheets.dto.PointShopDrawData;
 import aegis.server.domain.member.domain.Member;
 import aegis.server.domain.payment.dto.internal.PaymentInfo;
+import aegis.server.domain.pointshop.dto.internal.PointShopDrawInfo;
 import aegis.server.domain.survey.domain.Survey;
 import aegis.server.domain.survey.repository.SurveyRepository;
 import aegis.server.global.exception.CustomException;
@@ -28,10 +30,13 @@ public class GoogleSheetsService {
     private final Sheets sheets;
     private final SurveyRepository surveyRepository;
 
-    @Value("${google.spreadsheets.id}")
-    private String spreadsheetId;
-
+    @Value("${google.spreadsheets.registration.id}")
+    private String registrationSpreadsheetId;
     private static final String REGISTRATION_SHEET_RANGE = "database!A2:O";
+
+    @Value("${google.spreadsheets.pointshop.id}")
+    private String pointShopDrawSpreadsheetId;
+    private static final String POINT_SHOP_DRAW_SHEET_RANGE = "record!A2:F";
 
     public void addMemberRegistration(Member member, PaymentInfo paymentInfo) throws IOException {
         Survey survey = surveyRepository
@@ -57,7 +62,20 @@ public class GoogleSheetsService {
 
         sheets.spreadsheets()
                 .values()
-                .append(spreadsheetId, REGISTRATION_SHEET_RANGE, body)
+                .append(registrationSpreadsheetId, REGISTRATION_SHEET_RANGE, body)
+                .setValueInputOption("RAW")
+                .setInsertDataOption("INSERT_ROWS")
+                .execute();
+    }
+
+    public void addPointShopDraw(Member member, PointShopDrawInfo drawInfo) throws IOException {
+        PointShopDrawData row = PointShopDrawData.from(drawInfo, member);
+
+        ValueRange body = new ValueRange().setValues(List.of(row.toRowData()));
+
+        sheets.spreadsheets()
+                .values()
+                .append(pointShopDrawSpreadsheetId, POINT_SHOP_DRAW_SHEET_RANGE, body)
                 .setValueInputOption("RAW")
                 .setInsertDataOption("INSERT_ROWS")
                 .execute();

--- a/src/main/java/aegis/server/global/security/interceptor/StudyEnrollWindowInterceptor.java
+++ b/src/main/java/aegis/server/global/security/interceptor/StudyEnrollWindowInterceptor.java
@@ -52,13 +52,19 @@ public class StudyEnrollWindowInterceptor implements HandlerInterceptor {
         LocalDateTime parsedClose = parseLocalDateTime(closeAtProp);
 
         if (parsedOpen == null || parsedClose == null) {
-            log.warn("study.enroll-window.* 설정 형식이 올바르지 않습니다. 인터셉터를 비활성화합니다. open='{}', close='{}'", openAtProp, closeAtProp);
+            log.warn(
+                    "study.enroll-window.* 설정 형식이 올바르지 않습니다. 인터셉터를 비활성화합니다. open='{}', close='{}'",
+                    openAtProp,
+                    closeAtProp);
             this.enabled = false;
             return;
         }
 
         if (!parsedClose.isAfter(parsedOpen)) {
-            log.warn("study.enroll-window.close-at 이 open-at 보다 이후여야 합니다. 인터셉터를 비활성화합니다. open='{}', close='{}'", openAtProp, closeAtProp);
+            log.warn(
+                    "study.enroll-window.close-at 이 open-at 보다 이후여야 합니다. 인터셉터를 비활성화합니다. open='{}', close='{}'",
+                    openAtProp,
+                    closeAtProp);
             this.enabled = false;
             return;
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -73,4 +73,7 @@ google:
   credentials:
     json: ${GOOGLE_CREDENTIALS_JSON}
   spreadsheets:
-    id: ${GOOGLE_SPREADSHEET_ID}
+    registration:
+      id: ${REGISTRATION_GOOGLE_SPREADSHEET_ID}
+    pointshop:
+      id: ${POINTSHOP_GOOGLE_SPREADSHEET_ID}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 포인트샵 추첨 내역을 전용 Google 시트에 자동 저장합니다.
  * 추첨 이벤트를 비동기로 처리하여 저장 안정성을 개선했습니다.
* Chores
  * 환경설정에서 스프레드시트 ID를 등록/포인트샵으로 분리했습니다(운영 설정 업데이트 필요).
* 스타일
  * 경고 로그 포맷을 정리했습니다(동작 영향 없음).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->