### PR TITLE
feat(BE-292): 스터디 출석 현황 조회 추가

### DIFF
--- a/src/main/java/aegis/server/domain/study/controller/StudyInstructorController.java
+++ b/src/main/java/aegis/server/domain/study/controller/StudyInstructorController.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 
 import aegis.server.domain.study.dto.request.StudyCreateUpdateRequest;
 import aegis.server.domain.study.dto.response.AttendanceCodeIssueResponse;
+import aegis.server.domain.study.dto.response.AttendanceMatrixResponse;
 import aegis.server.domain.study.dto.response.GeneralStudyDetail;
 import aegis.server.domain.study.dto.response.InstructorStudyApplicationReason;
 import aegis.server.domain.study.dto.response.InstructorStudyApplicationSummary;
@@ -146,5 +147,20 @@ public class StudyInstructorController {
             @PathVariable Long studyId, @Parameter(hidden = true) @LoginUser UserDetails userDetails) {
         AttendanceCodeIssueResponse response = studyInstructorService.issueAttendanceCode(studyId, userDetails);
         return ResponseEntity.status(201).body(response);
+    }
+
+    @Operation(
+            summary = "회차별 출석 현황 조회",
+            description = "이름 기준 행, 회차 기준 열의 매트릭스를 반환합니다.",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "출석 현황 조회 성공"),
+                @ApiResponse(responseCode = "403", description = "스터디장이 아님", content = @Content),
+                @ApiResponse(responseCode = "404", description = "스터디를 찾을 수 없음", content = @Content)
+            })
+    @GetMapping("/studies/{studyId}/attendance-instructor")
+    public ResponseEntity<AttendanceMatrixResponse> getAttendanceMatrix(
+            @PathVariable Long studyId, @Parameter(hidden = true) @LoginUser UserDetails userDetails) {
+        AttendanceMatrixResponse response = studyInstructorService.findAttendanceMatrix(studyId, userDetails);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/aegis/server/domain/study/dto/response/AttendanceMatrixResponse.java
+++ b/src/main/java/aegis/server/domain/study/dto/response/AttendanceMatrixResponse.java
@@ -1,0 +1,11 @@
+package aegis.server.domain.study.dto.response;
+
+import java.util.List;
+
+public record AttendanceMatrixResponse(List<AttendanceSessionHeader> sessions, List<AttendanceMemberRow> members) {
+
+    public static AttendanceMatrixResponse from(
+            List<AttendanceSessionHeader> sessions, List<AttendanceMemberRow> members) {
+        return new AttendanceMatrixResponse(sessions, members);
+    }
+}

--- a/src/main/java/aegis/server/domain/study/dto/response/AttendanceMemberRow.java
+++ b/src/main/java/aegis/server/domain/study/dto/response/AttendanceMemberRow.java
@@ -1,0 +1,10 @@
+package aegis.server.domain.study.dto.response;
+
+import java.util.List;
+
+public record AttendanceMemberRow(Long memberId, String name, List<Boolean> attendance) {
+
+    public static AttendanceMemberRow from(Long memberId, String name, List<Boolean> attendance) {
+        return new AttendanceMemberRow(memberId, name, attendance);
+    }
+}

--- a/src/main/java/aegis/server/domain/study/dto/response/AttendanceSessionHeader.java
+++ b/src/main/java/aegis/server/domain/study/dto/response/AttendanceSessionHeader.java
@@ -1,0 +1,10 @@
+package aegis.server.domain.study.dto.response;
+
+import java.time.LocalDate;
+
+public record AttendanceSessionHeader(Long sessionId, LocalDate date) {
+
+    public static AttendanceSessionHeader from(Long sessionId, LocalDate date) {
+        return new AttendanceSessionHeader(sessionId, date);
+    }
+}

--- a/src/main/java/aegis/server/domain/study/repository/AttendanceMemberSessionPair.java
+++ b/src/main/java/aegis/server/domain/study/repository/AttendanceMemberSessionPair.java
@@ -1,0 +1,7 @@
+package aegis.server.domain.study.repository;
+
+public interface AttendanceMemberSessionPair {
+    Long getMemberId();
+
+    Long getSessionId();
+}

--- a/src/main/java/aegis/server/domain/study/repository/StudyAttendanceRepository.java
+++ b/src/main/java/aegis/server/domain/study/repository/StudyAttendanceRepository.java
@@ -1,10 +1,22 @@
 package aegis.server.domain.study.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import aegis.server.domain.study.domain.StudyAttendance;
 
 public interface StudyAttendanceRepository extends JpaRepository<StudyAttendance, Long> {
 
     boolean existsByStudySessionIdAndMemberId(Long studySessionId, Long memberId);
+
+    @Query(
+            """
+        SELECT sa.member.id AS memberId, sa.studySession.id AS sessionId
+        FROM StudyAttendance sa
+        JOIN sa.studySession ss
+        WHERE ss.study.id = :studyId
+        """)
+    List<AttendanceMemberSessionPair> findMemberSessionPairsByStudyId(Long studyId);
 }

--- a/src/main/java/aegis/server/domain/study/repository/StudySessionRepository.java
+++ b/src/main/java/aegis/server/domain/study/repository/StudySessionRepository.java
@@ -1,6 +1,7 @@
 package aegis.server.domain.study.repository;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,4 +13,6 @@ public interface StudySessionRepository extends JpaRepository<StudySession, Long
 
     @Query("SELECT ss FROM StudySession ss WHERE ss.study.id = :studyId AND ss.sessionDate = :sessionDate")
     Optional<StudySession> findByStudyIdAndSessionDate(Long studyId, LocalDate sessionDate);
+
+    List<StudySession> findAllByStudyIdOrderBySessionDateAsc(Long studyId);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 스터디 출석 현황 매트릭스 조회 기능 추가: 세션 날짜와 구성원별 출석 여부를 한 화면에서 확인 가능
  - 강사 전용 접근 지점 제공 및 권한 검증 강화
- 테스트
  - 세션/구성원 없음, 권한 오류, 교차 데이터 격리, 대규모(수십 세션·구성원), 전원 출석 등 다양한 시나리오의 테스트 추가로 안정성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->