### PR TITLE
feat(BE-294): 스터디 출석 시 포인트 지급 기능 추가

### DIFF
--- a/src/main/java/aegis/server/domain/study/domain/StudyAttendanceReward.java
+++ b/src/main/java/aegis/server/domain/study/domain/StudyAttendanceReward.java
@@ -1,0 +1,44 @@
+package aegis.server.domain.study.domain;
+
+import jakarta.persistence.*;
+
+import lombok.*;
+
+import aegis.server.domain.common.domain.BaseEntity;
+import aegis.server.domain.member.domain.Member;
+import aegis.server.domain.point.domain.PointTransaction;
+
+@Entity
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"study_session_id", "member_id"}))
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyAttendanceReward extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "study_attendance_reward_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_session_id")
+    private StudySession studySession;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member participant;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "point_transaction_id")
+    private PointTransaction pointTransaction;
+
+    public static StudyAttendanceReward create(
+            StudySession studySession, Member participant, PointTransaction pointTransaction) {
+        return StudyAttendanceReward.builder()
+                .studySession(studySession)
+                .participant(participant)
+                .pointTransaction(pointTransaction)
+                .build();
+    }
+}

--- a/src/main/java/aegis/server/domain/study/domain/StudySessionInstructorReward.java
+++ b/src/main/java/aegis/server/domain/study/domain/StudySessionInstructorReward.java
@@ -1,0 +1,44 @@
+package aegis.server.domain.study.domain;
+
+import jakarta.persistence.*;
+
+import lombok.*;
+
+import aegis.server.domain.common.domain.BaseEntity;
+import aegis.server.domain.member.domain.Member;
+import aegis.server.domain.point.domain.PointTransaction;
+
+@Entity
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"study_session_id", "member_id"}))
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudySessionInstructorReward extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "study_session_instructor_reward_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_session_id")
+    private StudySession studySession;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member instructor;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "point_transaction_id")
+    private PointTransaction pointTransaction;
+
+    public static StudySessionInstructorReward create(
+            StudySession studySession, Member instructor, PointTransaction pointTransaction) {
+        return StudySessionInstructorReward.builder()
+                .studySession(studySession)
+                .instructor(instructor)
+                .pointTransaction(pointTransaction)
+                .build();
+    }
+}

--- a/src/main/java/aegis/server/domain/study/domain/event/StudyAttendanceMarkedEvent.java
+++ b/src/main/java/aegis/server/domain/study/domain/event/StudyAttendanceMarkedEvent.java
@@ -1,0 +1,3 @@
+package aegis.server.domain.study.domain.event;
+
+public record StudyAttendanceMarkedEvent(Long studyId, Long sessionId, Long participantId) {}

--- a/src/main/java/aegis/server/domain/study/dto/request/StudyEnrollRequest.java
+++ b/src/main/java/aegis/server/domain/study/dto/request/StudyEnrollRequest.java
@@ -1,3 +1,6 @@
 package aegis.server.domain.study.dto.request;
 
-public record StudyEnrollRequest(String applicationReason) {}
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record StudyEnrollRequest(@NotBlank @Size(max = 500) String applicationReason) {}

--- a/src/main/java/aegis/server/domain/study/repository/StudyAttendanceRewardRepository.java
+++ b/src/main/java/aegis/server/domain/study/repository/StudyAttendanceRewardRepository.java
@@ -1,0 +1,10 @@
+package aegis.server.domain.study.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import aegis.server.domain.study.domain.StudyAttendanceReward;
+
+public interface StudyAttendanceRewardRepository extends JpaRepository<StudyAttendanceReward, Long> {
+
+    boolean existsByStudySessionIdAndParticipantId(Long studySessionId, Long participantId);
+}

--- a/src/main/java/aegis/server/domain/study/repository/StudyMemberRepository.java
+++ b/src/main/java/aegis/server/domain/study/repository/StudyMemberRepository.java
@@ -35,6 +35,9 @@ public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> 
         """)
     List<StudyMember> findByStudyIdAndRoleWithMember(Long studyId, StudyRole role);
 
+    @Query("SELECT sm FROM StudyMember sm WHERE sm.study.id = :studyId AND sm.role = :role")
+    Optional<StudyMember> findFirstByStudyIdAndRole(Long studyId, StudyRole role);
+
     @Query(
             """
         SELECT s.id

--- a/src/main/java/aegis/server/domain/study/repository/StudySessionInstructorRewardRepository.java
+++ b/src/main/java/aegis/server/domain/study/repository/StudySessionInstructorRewardRepository.java
@@ -1,0 +1,10 @@
+package aegis.server.domain.study.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import aegis.server.domain.study.domain.StudySessionInstructorReward;
+
+public interface StudySessionInstructorRewardRepository extends JpaRepository<StudySessionInstructorReward, Long> {
+
+    boolean existsByStudySessionIdAndInstructorId(Long studySessionId, Long instructorId);
+}

--- a/src/main/java/aegis/server/domain/study/service/listener/StudyPointEventListener.java
+++ b/src/main/java/aegis/server/domain/study/service/listener/StudyPointEventListener.java
@@ -1,0 +1,138 @@
+package aegis.server.domain.study.service.listener;
+
+import java.math.BigDecimal;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import aegis.server.domain.member.domain.Member;
+import aegis.server.domain.point.domain.PointAccount;
+import aegis.server.domain.point.domain.PointTransaction;
+import aegis.server.domain.point.domain.PointTransactionType;
+import aegis.server.domain.point.repository.PointAccountRepository;
+import aegis.server.domain.point.repository.PointTransactionRepository;
+import aegis.server.domain.study.domain.StudyAttendanceReward;
+import aegis.server.domain.study.domain.StudyMember;
+import aegis.server.domain.study.domain.StudyRole;
+import aegis.server.domain.study.domain.StudySession;
+import aegis.server.domain.study.domain.StudySessionInstructorReward;
+import aegis.server.domain.study.domain.event.StudyAttendanceMarkedEvent;
+import aegis.server.domain.study.repository.StudyAttendanceRewardRepository;
+import aegis.server.domain.study.repository.StudyMemberRepository;
+import aegis.server.domain.study.repository.StudySessionInstructorRewardRepository;
+import aegis.server.domain.study.repository.StudySessionRepository;
+import aegis.server.global.exception.CustomException;
+import aegis.server.global.exception.ErrorCode;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StudyPointEventListener {
+
+    private static final BigDecimal INSTRUCTOR_REWARD_POINT = BigDecimal.valueOf(30);
+    private static final BigDecimal PARTICIPANT_REWARD_POINT = BigDecimal.valueOf(10);
+
+    private final StudySessionRepository studySessionRepository;
+    private final StudyMemberRepository studyMemberRepository;
+    private final StudySessionInstructorRewardRepository studySessionInstructorRewardRepository;
+    private final StudyAttendanceRewardRepository studyAttendanceRewardRepository;
+    private final PointAccountRepository pointAccountRepository;
+    private final PointTransactionRepository pointTransactionRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleAttendanceMarked(StudyAttendanceMarkedEvent event) {
+        Long sessionId = event.sessionId();
+        Long participantId = event.participantId();
+
+        StudySession session = studySessionRepository
+                .findById(sessionId)
+                .orElseThrow(() -> new CustomException(ErrorCode.STUDY_SESSION_NOT_FOUND));
+
+        // 참가자 10 포인트 지급
+        try {
+            rewardParticipant(session, participantId);
+        } catch (DataIntegrityViolationException ignored) {
+        }
+
+        // 스터디장 30 포인트 지급
+        StudyMember instructorMember = studyMemberRepository
+                .findFirstByStudyIdAndRole(session.getStudy().getId(), StudyRole.INSTRUCTOR)
+                .orElse(null);
+
+        if (instructorMember == null) {
+            log.error(
+                    "[StudyPointEventListener][StudyAttendanceMarkedEvent] 스터디장 미등록으로 보상 생략: studyId={}, sessionId={}",
+                    session.getStudy().getId(),
+                    sessionId);
+            return;
+        }
+
+        Member instructor = instructorMember.getMember();
+        if (studySessionInstructorRewardRepository.existsByStudySessionIdAndInstructorId(
+                sessionId, instructor.getId())) {
+            return;
+        }
+
+        try {
+            rewardInstructor(session, instructor);
+        } catch (DataIntegrityViolationException ignored) {
+        }
+    }
+
+    private void rewardParticipant(StudySession session, Long participantId) {
+        if (studyAttendanceRewardRepository.existsByStudySessionIdAndParticipantId(session.getId(), participantId)) {
+            return;
+        }
+
+        PointAccount account = pointAccountRepository
+                .findByIdWithLock(participantId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POINT_ACCOUNT_NOT_FOUND));
+
+        account.add(PARTICIPANT_REWARD_POINT);
+
+        String reason = String.format("%s 스터디 출석", session.getStudy().getTitle());
+        PointTransaction tx =
+                PointTransaction.create(account, PointTransactionType.EARN, PARTICIPANT_REWARD_POINT, reason);
+        pointTransactionRepository.save(tx);
+
+        studyAttendanceRewardRepository.save(StudyAttendanceReward.create(session, account.getMember(), tx));
+
+        log.info(
+                "[StudyPointEventListener][StudyAttendanceMarkedEvent] 스터디원 보상 지급: studyId={}, sessionId={}, participantId={}, amount={}",
+                session.getStudy().getId(),
+                session.getId(),
+                participantId,
+                PARTICIPANT_REWARD_POINT);
+    }
+
+    private void rewardInstructor(StudySession session, Member instructor) {
+        PointAccount account = pointAccountRepository
+                .findByIdWithLock(instructor.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.POINT_ACCOUNT_NOT_FOUND));
+
+        account.add(INSTRUCTOR_REWARD_POINT);
+
+        String reason = String.format("%s 스터디 진행", session.getStudy().getTitle());
+        PointTransaction tx =
+                PointTransaction.create(account, PointTransactionType.EARN, INSTRUCTOR_REWARD_POINT, reason);
+        pointTransactionRepository.save(tx);
+
+        studySessionInstructorRewardRepository.save(StudySessionInstructorReward.create(session, instructor, tx));
+
+        log.info(
+                "[StudyPointEventListener][StudyAttendanceMarkedEvent] 스터디장 보상 지급: studyId={}, sessionId={}, instructorId={}, name={}, amount={}",
+                session.getStudy().getId(),
+                session.getId(),
+                instructor.getId(),
+                instructor.getName(),
+                INSTRUCTOR_REWARD_POINT);
+    }
+}

--- a/src/test/java/aegis/server/domain/study/service/StudyPointRewardTest.java
+++ b/src/test/java/aegis/server/domain/study/service/StudyPointRewardTest.java
@@ -1,0 +1,168 @@
+package aegis.server.domain.study.service;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import aegis.server.domain.member.domain.Member;
+import aegis.server.domain.point.domain.PointAccount;
+import aegis.server.domain.point.repository.PointAccountRepository;
+import aegis.server.domain.study.domain.*;
+import aegis.server.domain.study.dto.request.AttendanceMarkRequest;
+import aegis.server.domain.study.dto.response.AttendanceCodeIssueResponse;
+import aegis.server.domain.study.repository.StudyAttendanceRewardRepository;
+import aegis.server.domain.study.repository.StudyMemberRepository;
+import aegis.server.domain.study.repository.StudyRepository;
+import aegis.server.domain.study.repository.StudySessionInstructorRewardRepository;
+import aegis.server.helper.IntegrationTestWithoutTransactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+class StudyPointRewardTest extends IntegrationTestWithoutTransactional {
+
+    @Autowired
+    StudyParticipantService studyParticipantService;
+
+    @Autowired
+    StudyInstructorService studyInstructorService;
+
+    @Autowired
+    StudyRepository studyRepository;
+
+    @Autowired
+    StudyMemberRepository studyMemberRepository;
+
+    @Autowired
+    StudySessionInstructorRewardRepository sessionRewardRepository;
+
+    @Autowired
+    StudyAttendanceRewardRepository attendanceRewardRepository;
+
+    @Autowired
+    PointAccountRepository pointAccountRepository;
+
+    @MockitoBean
+    Clock clock;
+
+    @BeforeEach
+    void setupClock() {
+        given(clock.getZone()).willReturn(ZoneId.of("Asia/Seoul"));
+        given(clock.instant()).willReturn(Instant.parse("2025-09-11T01:00:00Z"));
+    }
+
+    @Test
+    void 첫_출석_발생_시_스터디장_30포인트_지급된다() {
+        // given
+        Member instructor = createMember();
+        Member participant = createMember();
+
+        PointAccount instructorAccount = pointAccountRepository.save(PointAccount.create(instructor));
+        pointAccountRepository.save(PointAccount.create(participant));
+        BigDecimal before = instructorAccount.getBalance();
+
+        Study study = createStudyWithInstructor(instructor);
+        addParticipant(study, participant);
+
+        AttendanceCodeIssueResponse issued =
+                studyInstructorService.issueAttendanceCode(study.getId(), createUserDetails(instructor));
+
+        // when: 첫 출석
+        studyParticipantService.markAttendance(
+                study.getId(), AttendanceMarkRequest.of(issued.code()), createUserDetails(participant));
+
+        // then: 스터디장 보상 1회 지급
+        PointAccount refreshed =
+                pointAccountRepository.findByMemberId(instructor.getId()).orElseThrow();
+        assertEquals(before.add(BigDecimal.valueOf(30)), refreshed.getBalance());
+        assertTrue(
+                sessionRewardRepository.existsByStudySessionIdAndInstructorId(issued.sessionId(), instructor.getId()));
+    }
+
+    @Test
+    void 여러_참가자_출석해도_스터디장_보상은_세션당_1회만_지급() {
+        // given
+        Member instructor = createMember();
+        Member p1 = createMember();
+        Member p2 = createMember();
+        pointAccountRepository.save(PointAccount.create(instructor));
+        pointAccountRepository.save(PointAccount.create(p1));
+        pointAccountRepository.save(PointAccount.create(p2));
+
+        Study study = createStudyWithInstructor(instructor);
+        addParticipant(study, p1);
+        addParticipant(study, p2);
+
+        AttendanceCodeIssueResponse issued =
+                studyInstructorService.issueAttendanceCode(study.getId(), createUserDetails(instructor));
+
+        // when: 두 명이 순차로 출석
+        studyParticipantService.markAttendance(
+                study.getId(), AttendanceMarkRequest.of(issued.code()), createUserDetails(p1));
+        studyParticipantService.markAttendance(
+                study.getId(), AttendanceMarkRequest.of(issued.code()), createUserDetails(p2));
+
+        // then: 보상은 1건만
+        assertTrue(
+                sessionRewardRepository.existsByStudySessionIdAndInstructorId(issued.sessionId(), instructor.getId()));
+        long rewardCount = sessionRewardRepository.findAll().stream()
+                .filter(r -> r.getStudySession().getId().equals(issued.sessionId()))
+                .count();
+        assertEquals(1L, rewardCount);
+    }
+
+    @Test
+    void 출석_성공_시_참가자_10포인트_지급() {
+        // given
+        Member instructor = createMember();
+        Member participant = createMember();
+        pointAccountRepository.save(PointAccount.create(instructor));
+        PointAccount participantAccount = pointAccountRepository.save(PointAccount.create(participant));
+        BigDecimal before = participantAccount.getBalance();
+
+        Study study = createStudyWithInstructor(instructor);
+        addParticipant(study, participant);
+
+        AttendanceCodeIssueResponse issued =
+                studyInstructorService.issueAttendanceCode(study.getId(), createUserDetails(instructor));
+
+        // when
+        studyParticipantService.markAttendance(
+                study.getId(), AttendanceMarkRequest.of(issued.code()), createUserDetails(participant));
+
+        // then
+        PointAccount refreshed =
+                pointAccountRepository.findByMemberId(participant.getId()).orElseThrow();
+        assertEquals(before.add(BigDecimal.valueOf(10)), refreshed.getBalance());
+        assertTrue(attendanceRewardRepository.existsByStudySessionIdAndParticipantId(
+                issued.sessionId(), participant.getId()));
+    }
+
+    private Study createStudyWithInstructor(Member instructor) {
+        Study study = Study.create(
+                "포인트 보상 스터디",
+                StudyCategory.WEB,
+                StudyLevel.BASIC,
+                "보상 테스트",
+                StudyRecruitmentMethod.APPLICATION,
+                10,
+                "주 1회",
+                java.util.List.of("커리큘럼1"),
+                java.util.List.of("자격1"));
+        study = studyRepository.save(study);
+
+        studyMemberRepository.save(StudyMember.create(study, instructor, StudyRole.INSTRUCTOR));
+        return study;
+    }
+
+    private void addParticipant(Study study, Member participant) {
+        studyMemberRepository.save(StudyMember.create(study, participant, StudyRole.PARTICIPANT));
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 새 기능
  * 출석 성공 시 참가자에게 10포인트가 자동 지급되며, 포인트 잔액/내역에 반영됩니다.
  * 각 세션에서 첫 출석이 발생하면 스터디장에게 30포인트가 자동 지급됩니다(세션당 1회, 중복 지급 방지).
  * 스터디 신청 시 ‘지원 사유’ 입력값 검증을 추가했습니다: 필수 입력이며 최대 500자까지 허용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->