### PR TITLE
refactor: 기본 serializer 대신 GenericJackson2JsonRedisSerializer 사용

### DIFF
--- a/src/main/java/aegis/server/global/config/RedisConfig.java
+++ b/src/main/java/aegis/server/global/config/RedisConfig.java
@@ -1,11 +1,63 @@
 package aegis.server.global.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisKeyValueAdapter;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.security.jackson2.SecurityJackson2Modules;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 @Configuration
 @EnableRedisRepositories(enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP)
 @Profile("!test")
-public class RedisConfig {}
+public class RedisConfig {
+
+    @Bean
+    public RedisSerializer<Object> redisValueSerializer() {
+        PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator.builder()
+                .allowIfSubType(Object.class)
+                .build();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.registerModules(
+                SecurityJackson2Modules.getModules(getClass().getClassLoader()));
+        objectMapper.activateDefaultTyping(typeValidator, ObjectMapper.DefaultTyping.NON_FINAL);
+        return new GenericJackson2JsonRedisSerializer(objectMapper);
+    }
+
+    // Spring Session이 기본 값 직렬화기로 사용
+    @Bean(name = "springSessionDefaultRedisSerializer")
+    public RedisSerializer<Object> springSessionDefaultRedisSerializer(RedisSerializer<Object> redisValueSerializer) {
+        return redisValueSerializer;
+    }
+
+    @Bean
+    @Primary
+    public RedisTemplate<Object, Object> redisTemplate(
+            RedisConnectionFactory connectionFactory, RedisSerializer<Object> redisValueSerializer) {
+        RedisTemplate<Object, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        StringRedisSerializer stringSerializer = new StringRedisSerializer();
+
+        template.setKeySerializer(stringSerializer);
+        template.setHashKeySerializer(stringSerializer);
+        template.setValueSerializer(redisValueSerializer);
+        template.setHashValueSerializer(redisValueSerializer);
+
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/src/main/java/aegis/server/global/security/oidc/CustomOidcUser.java
+++ b/src/main/java/aegis/server/global/security/oidc/CustomOidcUser.java
@@ -1,20 +1,41 @@
 package aegis.server.global.security.oidc;
 
+import java.util.Collection;
 import java.util.Collections;
 
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.Getter;
 
 import aegis.server.domain.member.domain.Member;
 
 @Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class CustomOidcUser extends DefaultOidcUser {
 
     private final UserDetails userDetails;
 
+    // Jackson용 생성자
+    @JsonCreator
+    public CustomOidcUser(
+            @JsonProperty("authorities") Collection<? extends GrantedAuthority> authorities,
+            @JsonProperty("idToken") OidcIdToken idToken,
+            @JsonProperty("userInfo") OidcUserInfo userInfo,
+            @JsonProperty("userDetails") UserDetails userDetails) {
+        super(authorities, idToken, userInfo);
+        this.userDetails = userDetails;
+    }
+
+    // 애플리케이션용 생성 경로
     public CustomOidcUser(OidcUser oidcUser, Member member) {
         super(
                 Collections.singleton(

--- a/src/main/java/aegis/server/global/security/oidc/UserDetails.java
+++ b/src/main/java/aegis/server/global/security/oidc/UserDetails.java
@@ -2,6 +2,9 @@ package aegis.server.global.security.oidc;
 
 import java.io.Serializable;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,6 +20,19 @@ public class UserDetails implements Serializable {
     private String email;
     private String name;
     private Role role;
+
+    // Jackson용 생성자
+    @JsonCreator
+    public UserDetails(
+            @JsonProperty("memberId") Long memberId,
+            @JsonProperty("email") String email,
+            @JsonProperty("name") String name,
+            @JsonProperty("role") Role role) {
+        this.memberId = memberId;
+        this.email = email;
+        this.name = name;
+        this.role = role;
+    }
 
     public static UserDetails from(Member member) {
         return UserDetails.builder()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 세션 및 캐시 직렬화 표준화로 Redis 기반 세션 안정성 향상.
* 버그 수정
  * OIDC 로그인 시 알 수 없는 필드가 포함된 사용자 정보도 안전하게 처리.
  * 사용자 정보(JSON) 역직렬화 정확도 개선으로 간헐적 로그인 오류 감소.
  * 날짜/시간 필드 직렬화 대응 강화로 세션/프로필 데이터 손상 방지.
* 작업
  * Redis 템플릿과 기본 세션 직렬화 설정 정비로 키/값 처리 일관성 강화.
  * 보안 모듈과의 직렬화 호환성 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->