### PR TITLE
fix: use SameSite=Lax for session cookies

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -15,5 +15,5 @@ server:
   servlet:
     session:
       cookie:
-        same-site: none
+        same-site: lax
         secure: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -15,5 +15,5 @@ server:
   servlet:
     session:
       cookie:
-        same-site: none
+        same-site: lax
         secure: true


### PR DESCRIPTION
## Summary

Set session cookies to `SameSite=Lax` in the `dev` and `prod` profiles.

All current web clients and API servers share the `dkuaegis.org` site, so cross-site cookie access is not expected to be required. This change may also prevent session cookies from being included in unintended cross-site requests.

## Verification

- `./gradlew check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 개발 및 프로덕션 환경에서 세션 쿠키의 SameSite 설정을 `Lax`로 변경해 브라우저의 쿠키 처리와 보안을 개선했습니다.
  * 개발 환경의 보안 쿠키 설정은 기존과 동일하게 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->